### PR TITLE
Introduce new pairing matching algorithm and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ REDIS_PASSWORD=change-me-in-production
 REDIS_URL=redis://:change-me-in-production@redis:6379
 
 # --- Pairing ---
-# Quiet window after the newest queued player before pairing. Higher values
-# create fuller OTB arena pairing pools but increase waiting time.
+# Arena quiet window after the newest queued player before pairing.
+# Lower values pair faster with thinner pools; higher values make fuller pools
+# but can reduce games played and increase long waits.
+# Common values to test: 10000, 20000, 30000, 45000.
 PAIRING_SETTLE_MS=30000

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ MONGO_URI=mongodb://mongo:27017/ntuarena?replicaSet=rs0
 #   DUMMY PASSWORD — set a real password in production
 REDIS_PASSWORD=change-me-in-production
 REDIS_URL=redis://:change-me-in-production@redis:6379
+
+# --- Pairing ---
+# Quiet window after the newest queued player before pairing. Higher values
+# create fuller OTB arena pairing pools but increase waiting time.
+PAIRING_SETTLE_MS=30000

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ view/.env
 # Build outputs
 view/build/
 backend/dist/
+backend/test-output/
 
 # OS generated files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Real-time OTB chess tournament management platform</strong><br>
-  Swiss-system &amp; Arena-style tournaments with automated pairing, live standings, and Elo tracking
+  Arena-style tournaments with automated pairing, live standings, and rating/performance tracking
 </p>
 
 <p align="center">
@@ -20,24 +20,34 @@
 
 ## About
 
-NTUArena is a web application built for **Skaki NTUA – Le Roi**, the chess club of the National Technical University of Athens. It manages over-the-board (OTB) chess tournaments with real-time game pairing, live standings, player statistics, and Elo rating tracking.
+NTUArena is a web application built for **Skaki NTUA - Le Roi**, the chess club of the National Technical University of Athens. It manages over-the-board chess tournaments with automated Arena pairings, live standings, player statistics, result submission, and rating/performance tracking.
+
+Arena is the complete real-time tournament path today. Swiss is still a roadmap item and should not be treated as production-ready pairing behavior.
 
 <p align="center">
-  <img src="assets/le-roi-logo.png" alt="Skaki NTUA – Le Roi" width="120" />
+  <img src="assets/le-roi-logo.png" alt="Skaki NTUA - Le Roi" width="120" />
   <br>
-  <em>Powered by Skaki NTUA – Le Roi</em>
+  <em>Powered by Skaki NTUA - Le Roi</em>
 </p>
 
 ## Features
 
-- **Tournament Management** — Create and manage Swiss-system and Arena-style tournaments
-- **Automated Pairing** — Players are paired automatically based on Elo, performance, and Swiss rules
-- **Live Standings** — Real-time leaderboard updates during tournaments
-- **Elo Rating System** — Automatic Elo calculation and tracking across tournaments
-- **Player Profiles** — Game history, statistics, and performance tracking
-- **Role-Based Access** — Admin, player, and spectator roles with JWT authentication
-- **CSV Import** — Bulk import players and users via CSV files
-- **Responsive UI** — Works on desktop and mobile browsers
+- **Tournament Management** - Create, start, monitor, and complete OTB tournaments.
+- **Arena Pairing Worker** - Redis-backed real-time queue with graph matching for available players.
+- **Graph-Based Pairing** - Maximum-weight matching over legal player-pair edges using Edmonds blossom matching.
+- **Pairing Controls** - Tune the Arena settle window with `PAIRING_SETTLE_MS` and validate choices with simulation/Pareto reports.
+- **Live Standings** - Real-time leaderboard updates during tournaments.
+- **Game Result Submission** - Admin result entry updates stats, ratings, histories, and pairing eligibility.
+- **Player Management** - Register users, import participants by CSV, pause/withdraw players who leave early.
+- **Role-Based Access** - Admin, player, and spectator roles with JWT authentication.
+- **Responsive UI** - Works on desktop and mobile browsers.
+
+## Important Docs
+
+- [Tournament Operations Guide](docs/tournament-operations.md): how to install, configure, tune pairing, and run an OTB Arena tournament.
+- [Testing and validation](docs/tournament-operations.md#5-testing-and-validation): backend tests, frontend checks, Docker health checks, and script validation.
+- [Pairing simulation tools](docs/tournament-operations.md#6-simulation-and-tuning-tools): one-hour simulations, Pareto plots, CSV/JSON/HTML outputs.
+- [Environment decisions](docs/tournament-operations.md#2-required-environment-decisions): deployment and tournament toggles.
 
 ## Tech Stack - Containers
 
@@ -46,13 +56,13 @@ NTUArena is a web application built for **Skaki NTUA – Le Roi**, the chess clu
 | **Frontend** | React, React Router |
 | **Backend** | Node.js, Express |
 | **Database** | MongoDB |
-| **Cache** | Redis |
+| **Queue/Cache** | Redis |
 | **Reverse Proxy** | Nginx |
 | **Containerization** | Docker Compose |
 
 ## High-Level Architecture
 
-```
+```text
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
 │   Browser   │────>│    Nginx    │────>│   React     │
 │             │     │  (port 80)  │     │  Frontend   │
@@ -67,7 +77,7 @@ NTUArena is a web application built for **Skaki NTUA – Le Roi**, the chess clu
                                     │                    │
                               ┌─────┴─────┐         ┌────┴────┐
                               │  MongoDB  │         │  Redis  │
-                              │ (replica) │         │ (cache) │
+                              │ (replica) │         │ (queue) │
                               └───────────┘         └─────────┘
 ```
 
@@ -75,7 +85,8 @@ NTUArena is a web application built for **Skaki NTUA – Le Roi**, the chess clu
 
 ### Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
 ### 1. Clone the repository
 
@@ -90,7 +101,7 @@ cd ArenaManager
 cp .env.example .env
 ```
 
-Edit `.env` to set your own values (JWT secret, passwords, etc.). See [Environment Variables](#environment-variables) for details.
+Edit `.env` before running a real tournament. At minimum, decide the app mode, auth mode, CORS origin, secrets, database/Redis credentials, and Arena pairing settle window.
 
 ### 3. Start the application
 
@@ -100,42 +111,64 @@ docker compose up -d --build
 
 ### 4. Open in browser
 
-```
+```text
 http://localhost
 ```
+
+For a complete operator checklist, see [Tournament Operations Guide](docs/tournament-operations.md).
+
+## Configuration Quick Reference
+
+These are the variables most likely to affect deployment and tournament behavior.
+
+| Variable | Purpose | Common values |
+|----------|---------|---------------|
+| `APP_MODE` | Selects frontend/Nginx mode | `dev`, `prod` |
+| `NODE_ENV` | Backend runtime mode | `development`, `production`, `test` |
+| `AUTH_ENABLED` | Enables real JWT auth | `false` for local/private tests, `true` for real/public use |
+| `CORS_ORIGIN` | Allowed browser origin | `*` locally, exact public origin in production |
+| `JWT_SECRET` | JWT signing secret | Generate a strong value for production |
+| `MONGO_URI` | Mongo connection string | Compose default or production Mongo URI |
+| `REDIS_URL` | Redis connection string | Required for pairing queue |
+| `PAIRING_SETTLE_MS` | Quiet window before Arena pairing | `10000`, `20000`, `30000`, `45000` |
+
+`PAIRING_SETTLE_MS` is the main pairing behavior toggle. Lower values create faster pairings with thinner waiting pools. Higher values create fuller pools for graph matching but can reduce games played and increase long waits. The default is `30000`.
+
+Full details: [Pairing Configuration](docs/tournament-operations.md#3-pairing-configuration).
 
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `APP_MODE` | `dev` or `prod` — selects Dockerfile and Nginx config | `dev` |
+| `APP_MODE` | `dev` or `prod`; selects Dockerfile and Nginx config | `dev` |
 | `PORT` | Backend server port | `5000` |
 | `NODE_ENV` | Node environment | `development` |
-| `AUTH_ENABLED` | Enable JWT authentication | `false` (recommended for local use) |
-| `JWT_SECRET` | Secret key for JWT tokens | *(change in production)* |
+| `AUTH_ENABLED` | Enable JWT authentication. If `false`, backend injects a mock admin user. | `false` |
+| `JWT_SECRET` | Secret key for JWT tokens | change in production |
 | `JWT_EXPIRES_IN` | Token expiration time | `7d` |
 | `MONGO_DB` | MongoDB database name | `ntuarena` |
 | `MONGO_URI` | MongoDB connection string | `mongodb://mongo:27017/ntuarena?replicaSet=rs0` |
-| `REDIS_PASSWORD` | Redis password | *(change in production)* |
+| `REDIS_PASSWORD` | Redis password | change in production |
 | `REDIS_URL` | Redis connection string | `redis://:password@redis:6379` |
 | `CORS_ORIGIN` | Allowed CORS origin | `*` |
+| `PAIRING_SETTLE_MS` | Arena pairing quiet window after newest queued player | `30000` |
 
 ## Dev vs Prod Mode
 
-Switch between development and production with a single env variable:
+Switch between development and production with `APP_MODE`:
 
 ```bash
 # .env
-APP_MODE=dev    # React dev server (hot reload)
-APP_MODE=prod   # Nginx serving static build
+APP_MODE=dev    # React dev server with hot reload
+APP_MODE=prod   # Nginx serving the built frontend
 ```
 
 | | Dev | Prod |
 |---|---|---|
 | **Frontend Dockerfile** | `Dockerfile.dev` | `Dockerfile.prod` |
-| **Nginx config** | `nginx.dev.conf` (→ port 3000) | `nginx.prod.conf` (→ port 80) |
-| **Hot reload** | ✅ | ❌ |
-| **Image size** | ~1 GB | ~25 MB |
+| **Nginx config** | `nginx.dev.conf` | `nginx.prod.conf` |
+| **Hot reload** | yes | no |
+| **Image size** | larger | smaller |
 
 After changing `APP_MODE`, rebuild:
 
@@ -143,43 +176,104 @@ After changing `APP_MODE`, rebuild:
 docker compose up -d --build
 ```
 
+After changing only backend env vars such as `PAIRING_SETTLE_MS`, recreate the backend container:
+
+```bash
+docker compose up -d --force-recreate backend
+```
+
+## Testing, Validation, And Simulation Commands
+
+Install dependencies before running local tests or simulations:
+
+```bash
+cd backend
+npm ci
+```
+
+Backend validation:
+
+```bash
+# Full backend test suite
+CORS_ORIGIN=http://localhost APP_MODE=test NODE_ENV=test npm test -- --runInBand
+
+# Pairing-focused tests
+npm test -- --runInBand pairingWorker.test.js
+
+# Syntax-check simulation scripts
+node --check test-scripts/simulateArenaPairings.js
+node --check test-scripts/simulatePairingComparison.js
+node --check test-scripts/simulatePairingPareto.js
+```
+
+Frontend validation:
+
+```bash
+cd ../view
+npm ci
+npm test -- --watchAll=false
+npm run build
+```
+
+Docker/runtime validation:
+
+```bash
+docker compose up -d --build
+docker compose ps
+docker compose logs -f backend
+```
+
+Pairing simulations:
+
+```bash
+cd ../backend
+npm run simulate:arena-pairings -- --players 20 --rounds 10 --seed 20260419
+npm run simulate:pairing-comparison -- --players 20 --durationMinutes 60 --settleSeconds 30 --seed 20260519
+npm run simulate:pairing-pareto
+```
+
+Reports are written to `backend/test-output/`. The Pareto report plots throughput, wait time, pool size, and problematic configurations for different player counts and settle windows.
+
+## Running An OTB Arena Tournament
+
+Short version:
+
+1. Copy `.env.example` to `.env` and set production-safe secrets if needed.
+2. Choose `APP_MODE`, `AUTH_ENABLED`, `CORS_ORIGIN`, and `PAIRING_SETTLE_MS`.
+3. Start with `docker compose up -d --build`.
+4. Create an Arena tournament from the admin UI.
+5. Register/import players.
+6. Start the tournament. This seeds Redis and starts the pairing worker.
+7. Enter results as games finish; games can finish asynchronously.
+8. Pause or withdraw players who leave early.
+9. Monitor standings, live games, and backend logs.
+10. Complete the tournament from the admin UI.
+
+Detailed runbook: [Tournament Operations Guide](docs/tournament-operations.md#4-running-a-tournament).
+
 ## Project Structure
 
-```
+```text
 ArenaManager/
 ├── assets/                  # Logos and static assets
 ├── backend/
 │   ├── src/
 │   │   ├── controllers/     # Route handlers
 │   │   ├── middleware/      # Auth, validation
-│   │   ├── models/          # Mongoose schemas (User, Player, Tournament, Game)
+│   │   ├── models/          # Mongoose schemas
 │   │   ├── routes/          # Express route definitions
-│   │   ├── services/        # Business logic (pairing, Elo, etc.)
+│   │   ├── services/        # Business logic, pairing, ratings
 │   │   ├── utils/           # Helpers
 │   │   └── server.js        # Express app entry point
+│   ├── test-scripts/        # Tournament/pairing simulations
 │   ├── Dockerfile
 │   └── package.json
-├── view/
-│   ├── src/
-│   │   ├── components/      # Reusable UI components
-│   │   ├── contexts/        # React contexts (auth)
-│   │   ├── pages/           # Page components
-│   │   ├── services/        # API client
-│   │   └── App.js           # Root component
-│   ├── Dockerfile.dev       # Development (React dev server)
-│   ├── Dockerfile.prod      # Production (multi-stage Nginx build)
-│   └── package.json
-├── nginx/
-│   ├── nginx.dev.conf       # Dev: proxies to frontend:3000
-│   └── nginx.prod.conf      # Prod: proxies to frontend:80
-├── scripts/
-│   └── backup-mongo.sh      # Database backup script
-├── seed/                    # Database seed data
-├── docs/                    # API docs and diagrams
+├── view/                    # React frontend
+├── nginx/                   # Dev/prod reverse proxy configs
+├── scripts/                 # Operational scripts
+├── docs/                    # Runbooks, API notes, diagrams
 ├── docker-compose.yml
-├── .env.example
-└── .github/
-    └── dependabot.yml       # Grouped dependency updates
+└── .env.example
 ```
 
 ## Database Backup
@@ -194,28 +288,28 @@ Run a manual backup:
 
 See [SECURITY.md](SECURITY.md) for our security policy and vulnerability reporting guidelines.
 
-**Key security measures:**
-- JWT authentication with bcrypt password hashing
-- NoSQL injection prevention (`express-mongo-sanitize`)
-- Rate limiting on all API endpoints
-- CORS origin restriction
-- All secrets in environment variables
+Key security measures:
+
+- JWT authentication with bcrypt password hashing.
+- NoSQL injection prevention.
+- Rate limiting on API endpoints.
+- CORS origin restriction.
+- Secrets configured through environment variables.
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/my-feature`)
-3. Commit your changes (`git commit -m 'Add my feature'`)
-4. Push to the branch (`git push origin feature/my-feature`)
-5. Open a Pull Request
+1. Fork the repository.
+2. Create a feature branch: `git checkout -b feature/my-feature`.
+3. Commit your changes: `git commit -m 'Add my feature'`.
+4. Push to the branch: `git push origin feature/my-feature`.
+5. Open a pull request.
 
 ## License
 
-This project is licensed under the [GNU General Public License v3.0](LICENSE).  
-You are free to use, modify, and distribute this software under the terms of the GPL-3.0. Any derivative work must also be distributed under the same license.
+This project is licensed under the [GNU General Public License v3.0](LICENSE). You are free to use, modify, and distribute this software under the terms of the GPL-3.0. Any derivative work must also be distributed under the same license.
 
 ---
 
 <p align="center">
-  Made with ♟️ by <strong>Skaki NTUA – Le Roi</strong>
+  Made by <strong>Skaki NTUA - Le Roi</strong>
 </p>

--- a/backend/__tests__/pairingWorker.test.js
+++ b/backend/__tests__/pairingWorker.test.js
@@ -2,6 +2,26 @@ const {
 	selectBatchPairings,
 	selectGreedyBatchPairings,
 } = require('../src/services/pairing/selectBatchPairings');
+const {
+	DEFAULT_PAIRING_SETTLE_MS,
+	parsePairingSettleMs,
+} = require('../src/services/pairing/pairingConfig');
+
+describe('pairing settle config', () => {
+	test('defaults to a 30 second quiet window', () => {
+		expect(DEFAULT_PAIRING_SETTLE_MS).toBe(30_000);
+		expect(parsePairingSettleMs()).toBe(30_000);
+		expect(parsePairingSettleMs('')).toBe(30_000);
+		expect(parsePairingSettleMs('not-a-number')).toBe(30_000);
+		expect(parsePairingSettleMs('-1')).toBe(30_000);
+	});
+
+	test('accepts explicit non-negative millisecond values', () => {
+		expect(parsePairingSettleMs('0')).toBe(0);
+		expect(parsePairingSettleMs('45000')).toBe(45_000);
+		expect(parsePairingSettleMs(20_000)).toBe(20_000);
+	});
+});
 
 describe('selectBatchPairings', () => {
 	const makePlayer = (_id) => ({ _id });

--- a/backend/__tests__/pairingWorker.test.js
+++ b/backend/__tests__/pairingWorker.test.js
@@ -1,4 +1,7 @@
-const { selectBatchPairings } = require('../src/services/pairing/selectBatchPairings');
+const {
+	selectBatchPairings,
+	selectGreedyBatchPairings,
+} = require('../src/services/pairing/selectBatchPairings');
 
 describe('selectBatchPairings', () => {
 	const makePlayer = (_id) => ({ _id });
@@ -12,7 +15,7 @@ describe('selectBatchPairings', () => {
 		expect(result.pairings).toEqual([]);
 		expect(result.leftovers.map((player) => player._id).sort()).toEqual(['A', 'B', 'C', 'D']);
 		expect(result.exhaustedNoLegalPairPool).toBe(true);
-		expect(evaluator).toHaveBeenCalledTimes(12);
+		expect(evaluator).toHaveBeenCalledTimes(6);
 	});
 
 	test('finds a legal pairing among three players after rotating away from an unmatched anchor', () => {
@@ -37,5 +40,59 @@ describe('selectBatchPairings', () => {
 		expect(result.pairings[0].white._id).toBe('B');
 		expect(result.pairings[0].black._id).toBe('C');
 		expect(result.leftovers.map((player) => player._id)).toEqual(['A']);
+	});
+
+	test('graph selector maximizes game count when greedy anchor choice blocks a second game', () => {
+		const players = ['A', 'B', 'C', 'D'].map(makePlayer);
+		const evaluator = (left, right) => {
+			const ids = [left._id, right._id].sort().join('');
+			const scores = {
+				AB: 0.99,
+				AC: 0.9,
+				BD: 0.9,
+			};
+			if (scores[ids] == null) return { ok: false };
+			return {
+				ok: true,
+				score: scores[ids],
+				colors: { white: left, black: right },
+			};
+		};
+
+		const greedy = selectGreedyBatchPairings(players, evaluator);
+		const graph = selectBatchPairings(players, evaluator);
+
+		expect(greedy.pairings).toHaveLength(1);
+		expect(graph.pairings).toHaveLength(2);
+		expect(graph.leftovers).toEqual([]);
+		expect(graph.usedFallback).toBe(false);
+	});
+
+	test('graph selector maximizes total score among maximum-cardinality matchings', () => {
+		const players = ['A', 'B', 'C', 'D'].map(makePlayer);
+		const evaluator = (left, right) => {
+			const ids = [left._id, right._id].sort().join('');
+			const scores = {
+				AB: 10,
+				CD: 1,
+				AC: 8,
+				BD: 8,
+			};
+			if (scores[ids] == null) return { ok: false };
+			return {
+				ok: true,
+				score: scores[ids],
+				colors: { white: left, black: right },
+			};
+		};
+
+		const graph = selectBatchPairings(players, evaluator);
+		const pairIds = graph.pairings
+			.map(({ white, black }) => [white._id, black._id].sort().join(''))
+			.sort();
+
+		expect(graph.pairings).toHaveLength(2);
+		expect(graph.totalPairingScore).toBe(16);
+		expect(pairIds).toEqual(['AC', 'BD']);
 	});
 });

--- a/backend/__tests__/pairingWorker.test.js
+++ b/backend/__tests__/pairingWorker.test.js
@@ -95,4 +95,20 @@ describe('selectBatchPairings', () => {
 		expect(graph.totalPairingScore).toBe(16);
 		expect(pairIds).toEqual(['AC', 'BD']);
 	});
+
+	test('graph selector supports components larger than the old exact-DP cap', () => {
+		const players = Array.from({ length: 30 }, (_, index) => makePlayer(`P${String(index + 1).padStart(2, '0')}`));
+		const evaluator = (left, right) => ({
+			ok: true,
+			score: 1 - Math.abs(Number(left._id.slice(1)) - Number(right._id.slice(1))) / 100,
+			colors: { white: left, black: right },
+		});
+
+		const graph = selectBatchPairings(players, evaluator);
+
+		expect(graph.pairings).toHaveLength(15);
+		expect(graph.leftovers).toEqual([]);
+		expect(graph.usedFallback).toBe(false);
+		expect(graph.legalEdgeCount).toBe(435);
+	});
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "bcryptjs": "3.0.3",
         "cors": "2.8.6",
         "dotenv": "17.4.2",
+        "edmonds-blossom-fixed": "^1.0.1",
         "express": "5.2.1",
         "express-mongo-sanitize": "2.2.0",
         "express-rate-limit": "8.3.2",
@@ -2572,6 +2573,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/edmonds-blossom-fixed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/edmonds-blossom-fixed/-/edmonds-blossom-fixed-1.0.1.tgz",
+      "integrity": "sha512-wtpraSt4yJeUpNU8RGC4q2JBxsJbHFxI7/htm/mS4FgxSN90WBwmgE7QZwpcY70KJRqmfLCNxU49UIc+DfzLKQ==",
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "simulate:tournament": "node test-scripts/simulateTournament.js",
     "simulate:arena-pairings": "node test-scripts/simulateArenaPairings.js",
     "simulate:pairing-comparison": "node test-scripts/simulatePairingComparison.js",
+    "simulate:pairing-pareto": "node test-scripts/simulatePairingPareto.js",
     "audit:full": "npm audit && npx @socketsecurity/cli@latest ci"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "dev": "nodemon src/server.js",
     "test": "jest --forceExit --detectOpenHandles",
     "simulate:tournament": "node test-scripts/simulateTournament.js",
-    "simulate:arena-pairings": "node test-scripts/simulateArenaPairings.js"
+    "simulate:arena-pairings": "node test-scripts/simulateArenaPairings.js",
+    "simulate:pairing-comparison": "node test-scripts/simulatePairingComparison.js",
     "audit:full": "npm audit && npx @socketsecurity/cli@latest ci"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "bcryptjs": "3.0.3",
     "cors": "2.8.6",
     "dotenv": "17.4.2",
+    "edmonds-blossom-fixed": "^1.0.1",
     "express": "5.2.1",
     "express-mongo-sanitize": "2.2.0",
     "express-rate-limit": "8.3.2",

--- a/backend/src/services/pairing/pairingConfig.js
+++ b/backend/src/services/pairing/pairingConfig.js
@@ -1,0 +1,19 @@
+const DEFAULT_PAIRING_SETTLE_MS = 30_000;
+
+function parsePairingSettleMs(value = process.env.PAIRING_SETTLE_MS) {
+	if (value === undefined || value === null || value === '') {
+		return DEFAULT_PAIRING_SETTLE_MS;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return DEFAULT_PAIRING_SETTLE_MS;
+	}
+
+	return Math.round(parsed);
+}
+
+module.exports = {
+	DEFAULT_PAIRING_SETTLE_MS,
+	parsePairingSettleMs,
+};

--- a/backend/src/services/pairing/pairingWorker.js
+++ b/backend/src/services/pairing/pairingWorker.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const { enqueue, batchDequeueToPending, ackFromPending, requeueLeftovers, reclaimPending, removeSnapshotsFromPending } = require('../queue/redisQueue');
 const { evaluatePair } = require('./pairingScorer');
+const { DEFAULT_PAIRING_SETTLE_MS } = require('./pairingConfig');
 const { selectBatchPairings } = require('./selectBatchPairings');
 
 const gameService = require('../gameService');
@@ -19,7 +20,7 @@ class PairingWorker {
 	 *        a new pairing round fires, maximising the available player pool.
 	 *        Set to 0 to disable.
 	 */
-	constructor({ workerId = 'w1', batchSize = 80, idleMs = 400, settleMs = 10_000 } = {}) {
+	constructor({ workerId = 'w1', batchSize = 80, idleMs = 400, settleMs = DEFAULT_PAIRING_SETTLE_MS } = {}) {
 		this.workerId = workerId;
 		this.batchSize = batchSize;
 		this.idleMs = idleMs;

--- a/backend/src/services/pairing/selectBatchPairings.js
+++ b/backend/src/services/pairing/selectBatchPairings.js
@@ -1,10 +1,30 @@
 const { evaluatePair } = require('./pairingScorer');
 
-function selectBatchPairings(batch, evaluatePairFn = evaluatePair) {
+const DEFAULT_MAX_EXACT_COMPONENT_VERTICES = 24;
+const EPSILON = 1e-9;
+
+function isBetterMatch(candidate, incumbent) {
+	if (!incumbent) return true;
+	if (candidate.count !== incumbent.count) return candidate.count > incumbent.count;
+	if (Math.abs(candidate.score - incumbent.score) > EPSILON) {
+		return candidate.score > incumbent.score;
+	}
+	return candidate.tieKey < incumbent.tieKey;
+}
+
+function pairTieKey(edges) {
+	return edges
+		.map((edge) => `${String(edge.colors.white._id)}-${String(edge.colors.black._id)}`)
+		.sort()
+		.join('|');
+}
+
+function selectGreedyBatchPairings(batch, evaluatePairFn = evaluatePair) {
 	const remaining = [...batch];
 	const pairings = [];
 	let stalledRotations = 0;
 	let exhaustedNoLegalPairPool = false;
+	let totalPairingScore = 0;
 
 	while (remaining.length >= 2) {
 		const anchor = remaining[0];
@@ -34,9 +54,191 @@ function selectBatchPairings(batch, evaluatePairFn = evaluatePair) {
 		remaining.splice(bestIdx, 1);
 		remaining.shift();
 		pairings.push(bestEval.colors);
+		totalPairingScore += bestEval.score;
 	}
 
-	return { pairings, leftovers: remaining, exhaustedNoLegalPairPool };
+	return {
+		pairings,
+		leftovers: remaining,
+		exhaustedNoLegalPairPool,
+		strategy: 'greedy',
+		usedFallback: false,
+		totalPairingScore,
+		legalEdgeCount: null,
+	};
 }
 
-module.exports = { selectBatchPairings };
+function buildPairingGraph(batch, evaluatePairFn = evaluatePair) {
+	const edges = [];
+	const adjacency = Array.from({ length: batch.length }, () => []);
+
+	for (let i = 0; i < batch.length; i++) {
+		for (let j = i + 1; j < batch.length; j++) {
+			const evaluation = evaluatePairFn(batch[i], batch[j]);
+			if (!evaluation.ok) continue;
+
+			const edge = {
+				i,
+				j,
+				score: evaluation.score,
+				colors: evaluation.colors,
+			};
+			edges.push(edge);
+			adjacency[i].push(edge);
+			adjacency[j].push(edge);
+		}
+	}
+
+	return { edges, adjacency };
+}
+
+function connectedComponents(vertexCount, adjacency) {
+	const visited = new Array(vertexCount).fill(false);
+	const components = [];
+
+	for (let start = 0; start < vertexCount; start++) {
+		if (visited[start]) continue;
+
+		const vertices = [];
+		const stack = [start];
+		visited[start] = true;
+
+		while (stack.length) {
+			const vertex = stack.pop();
+			vertices.push(vertex);
+
+			for (const edge of adjacency[vertex]) {
+				const next = edge.i === vertex ? edge.j : edge.i;
+				if (visited[next]) continue;
+				visited[next] = true;
+				stack.push(next);
+			}
+		}
+
+		components.push(vertices.sort((a, b) => a - b));
+	}
+
+	return components;
+}
+
+function solveExactComponent(vertices, adjacency) {
+	const localIndex = new Map(vertices.map((vertex, index) => [vertex, index]));
+	const localEdges = Array.from({ length: vertices.length }, () => []);
+
+	for (const vertex of vertices) {
+		const sourceLocal = localIndex.get(vertex);
+		for (const edge of adjacency[vertex]) {
+			const other = edge.i === vertex ? edge.j : edge.i;
+			if (!localIndex.has(other)) continue;
+			const targetLocal = localIndex.get(other);
+			if (sourceLocal < targetLocal) {
+				localEdges[sourceLocal].push({ ...edge, targetLocal });
+			}
+		}
+	}
+
+	const memo = new Map();
+	const fullMask = (1n << BigInt(vertices.length)) - 1n;
+
+	function solve(mask) {
+		if (mask === 0n) return { count: 0, score: 0, edges: [], tieKey: '' };
+		if (memo.has(mask)) return memo.get(mask);
+
+		let firstLocal = 0;
+		while ((mask & (1n << BigInt(firstLocal))) === 0n) {
+			firstLocal += 1;
+		}
+
+		const firstBit = 1n << BigInt(firstLocal);
+		const withoutFirst = mask & ~firstBit;
+		let best = solve(withoutFirst);
+
+		for (const edge of localEdges[firstLocal]) {
+			const targetBit = 1n << BigInt(edge.targetLocal);
+			if ((mask & targetBit) === 0n) continue;
+
+			const rest = solve(withoutFirst & ~targetBit);
+			const candidateEdges = [...rest.edges, edge];
+			const candidate = {
+				count: rest.count + 1,
+				score: rest.score + edge.score,
+				edges: candidateEdges,
+				tieKey: pairTieKey(candidateEdges),
+			};
+
+			if (isBetterMatch(candidate, best)) best = candidate;
+		}
+
+		memo.set(mask, best);
+		return best;
+	}
+
+	return solve(fullMask);
+}
+
+function hasLegalLeftoverEdge(leftovers, graphEdges, batch) {
+	const leftoverIds = new Set(leftovers.map((player) => String(player._id)));
+	return graphEdges.some((edge) => (
+		leftoverIds.has(String(batch[edge.i]._id)) &&
+		leftoverIds.has(String(batch[edge.j]._id))
+	));
+}
+
+function selectGraphBatchPairings(batch, evaluatePairFn = evaluatePair, options = {}) {
+	const maxExactComponentVertices = options.maxExactComponentVertices ?? DEFAULT_MAX_EXACT_COMPONENT_VERTICES;
+	const graph = buildPairingGraph(batch, evaluatePairFn);
+	const components = connectedComponents(batch.length, graph.adjacency);
+	const pairings = [];
+	const matchedIndexes = new Set();
+	let usedFallback = false;
+	let totalPairingScore = 0;
+
+	for (const component of components) {
+		if (component.length < 2) continue;
+
+		if (component.length > maxExactComponentVertices) {
+			usedFallback = true;
+			const componentBatch = component.map((index) => batch[index]);
+			const fallback = selectGreedyBatchPairings(componentBatch, evaluatePairFn);
+			for (const pairing of fallback.pairings) {
+				pairings.push(pairing);
+				matchedIndexes.add(batch.findIndex((player) => String(player._id) === String(pairing.white._id)));
+				matchedIndexes.add(batch.findIndex((player) => String(player._id) === String(pairing.black._id)));
+			}
+			totalPairingScore += fallback.totalPairingScore;
+			continue;
+		}
+
+		const solution = solveExactComponent(component, graph.adjacency);
+		const selectedEdges = [...solution.edges].sort((left, right) => Math.min(left.i, left.j) - Math.min(right.i, right.j));
+
+		for (const edge of selectedEdges) {
+			pairings.push(edge.colors);
+			matchedIndexes.add(edge.i);
+			matchedIndexes.add(edge.j);
+			totalPairingScore += edge.score;
+		}
+	}
+
+	const leftovers = batch.filter((_, index) => !matchedIndexes.has(index));
+	const exhaustedNoLegalPairPool = leftovers.length >= 2 && !hasLegalLeftoverEdge(leftovers, graph.edges, batch);
+
+	return {
+		pairings,
+		leftovers,
+		exhaustedNoLegalPairPool,
+		strategy: 'graph',
+		usedFallback,
+		totalPairingScore,
+		legalEdgeCount: graph.edges.length,
+	};
+}
+
+const selectBatchPairings = selectGraphBatchPairings;
+
+module.exports = {
+	selectBatchPairings,
+	selectGraphBatchPairings,
+	selectGreedyBatchPairings,
+	buildPairingGraph,
+};

--- a/backend/src/services/pairing/selectBatchPairings.js
+++ b/backend/src/services/pairing/selectBatchPairings.js
@@ -1,23 +1,15 @@
+const blossom = require('edmonds-blossom-fixed');
 const { evaluatePair } = require('./pairingScorer');
 
-const DEFAULT_MAX_EXACT_COMPONENT_VERTICES = 24;
-const EPSILON = 1e-9;
-
-function isBetterMatch(candidate, incumbent) {
-	if (!incumbent) return true;
-	if (candidate.count !== incumbent.count) return candidate.count > incumbent.count;
-	if (Math.abs(candidate.score - incumbent.score) > EPSILON) {
-		return candidate.score > incumbent.score;
-	}
-	return candidate.tieKey < incumbent.tieKey;
-}
-
-function pairTieKey(edges) {
-	return edges
-		.map((edge) => `${String(edge.colors.white._id)}-${String(edge.colors.black._id)}`)
-		.sort()
-		.join('|');
-}
+const DEFAULT_PAIRING_COST_WEIGHTS = {
+	legacyScore: 100,
+	headToHead: 250,
+	rank: 300,
+	rating: 140,
+	ratingDeviation: 60,
+	berserk: 40,
+	wait: 35,
+};
 
 function selectGreedyBatchPairings(batch, evaluatePairFn = evaluatePair) {
 	const remaining = [...batch];
@@ -68,24 +60,112 @@ function selectGreedyBatchPairings(batch, evaluatePairFn = evaluatePair) {
 	};
 }
 
-function buildPairingGraph(batch, evaluatePairFn = evaluatePair) {
+function asFiniteNumber(value, fallback = null) {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function colorTailStreak(history, color) {
+	let streak = 0;
+	for (let i = (history ?? []).length - 1; i >= 0; i--) {
+		if (history[i] !== color) break;
+		streak += 1;
+	}
+	return streak;
+}
+
+function playerRank(player) {
+	return asFiniteNumber(player.standing ?? player.rank, null);
+}
+
+function playerRating(player) {
+	return asFiniteNumber(player.liveRating ?? player.entryRating ?? player.rating, 1200);
+}
+
+function playerRatingDeviation(player) {
+	return asFiniteNumber(player.ratingDeviation ?? player.rd ?? player.ratingDeviationValue, null);
+}
+
+function playerBerserkRate(player) {
+	return asFiniteNumber(player.berserkRate ?? player.zerkRate, null);
+}
+
+function headToHeadCount(a, b) {
+	const bId = String(b._id);
+	return (a.recentOpponents ?? []).filter((opponentId) => String(opponentId) === bId).length;
+}
+
+function normalizedDiff(left, right, scale) {
+	if (left == null || right == null) return 0;
+	return Math.tanh(Math.abs(left - right) / scale);
+}
+
+function averageWaitMinutes(a, b) {
+	const now = Date.now();
+	const waitA = a.waitingSince ? Math.max(0, now - new Date(a.waitingSince).getTime()) : 0;
+	const waitB = b.waitingSince ? Math.max(0, now - new Date(b.waitingSince).getTime()) : 0;
+	return (waitA + waitB) / 2 / 60000;
+}
+
+function forcedColorStress(player, color) {
+	const opposite = color === 'white' ? 'black' : 'white';
+	return colorTailStreak(player.colorHistory, opposite) >= 2 ? 0.2 : 0;
+}
+
+function pairingCost(a, b, evaluation, weights = DEFAULT_PAIRING_COST_WEIGHTS) {
+	const meetings = Math.max(headToHeadCount(a, b), headToHeadCount(b, a));
+	const rankA = playerRank(a);
+	const rankB = playerRank(b);
+	const rdA = playerRatingDeviation(a);
+	const rdB = playerRatingDeviation(b);
+	const berserkA = playerBerserkRate(a);
+	const berserkB = playerBerserkRate(b);
+	const colorStress =
+		forcedColorStress(evaluation.colors.white, 'white') +
+		forcedColorStress(evaluation.colors.black, 'black');
+
+	return (
+		-weights.legacyScore * (evaluation.score + colorStress) +
+		weights.headToHead * Math.min(meetings, 2) / 2 +
+		weights.rank * normalizedDiff(rankA, rankB, 8) +
+		weights.rating * normalizedDiff(playerRating(a), playerRating(b), 400) +
+		weights.ratingDeviation * normalizedDiff(rdA, rdB, 80) +
+		weights.berserk * normalizedDiff(berserkA, berserkB, 0.35) -
+		weights.wait * Math.tanh(averageWaitMinutes(a, b) / 3)
+	);
+}
+
+function buildPairingGraph(batch, evaluatePairFn = evaluatePair, options = {}) {
 	const edges = [];
 	const adjacency = Array.from({ length: batch.length }, () => []);
+	const costWeights = {
+		...DEFAULT_PAIRING_COST_WEIGHTS,
+		...(options.costWeights ?? {}),
+	};
 
 	for (let i = 0; i < batch.length; i++) {
 		for (let j = i + 1; j < batch.length; j++) {
 			const evaluation = evaluatePairFn(batch[i], batch[j]);
 			if (!evaluation.ok) continue;
+			const cost = pairingCost(batch[i], batch[j], evaluation, costWeights);
 
 			const edge = {
 				i,
 				j,
 				score: evaluation.score,
+				cost,
 				colors: evaluation.colors,
 			};
 			edges.push(edge);
 			adjacency[i].push(edge);
 			adjacency[j].push(edge);
+		}
+	}
+
+	if (edges.length) {
+		const maxCost = Math.max(...edges.map((edge) => edge.cost));
+		for (const edge of edges) {
+			edge.matchWeight = Math.max(1, Math.round((maxCost - edge.cost) * 1000) + 1);
 		}
 	}
 
@@ -121,9 +201,10 @@ function connectedComponents(vertexCount, adjacency) {
 	return components;
 }
 
-function solveExactComponent(vertices, adjacency) {
+function solveBlossomComponent(vertices, adjacency) {
 	const localIndex = new Map(vertices.map((vertex, index) => [vertex, index]));
-	const localEdges = Array.from({ length: vertices.length }, () => []);
+	const localEdges = [];
+	const edgeByLocalPair = new Map();
 
 	for (const vertex of vertices) {
 		const sourceLocal = localIndex.get(vertex);
@@ -132,48 +213,24 @@ function solveExactComponent(vertices, adjacency) {
 			if (!localIndex.has(other)) continue;
 			const targetLocal = localIndex.get(other);
 			if (sourceLocal < targetLocal) {
-				localEdges[sourceLocal].push({ ...edge, targetLocal });
+				localEdges.push([sourceLocal, targetLocal, edge.matchWeight]);
+				edgeByLocalPair.set(`${sourceLocal}:${targetLocal}`, edge);
 			}
 		}
 	}
 
-	const memo = new Map();
-	const fullMask = (1n << BigInt(vertices.length)) - 1n;
+	if (!localEdges.length) return [];
 
-	function solve(mask) {
-		if (mask === 0n) return { count: 0, score: 0, edges: [], tieKey: '' };
-		if (memo.has(mask)) return memo.get(mask);
-
-		let firstLocal = 0;
-		while ((mask & (1n << BigInt(firstLocal))) === 0n) {
-			firstLocal += 1;
-		}
-
-		const firstBit = 1n << BigInt(firstLocal);
-		const withoutFirst = mask & ~firstBit;
-		let best = solve(withoutFirst);
-
-		for (const edge of localEdges[firstLocal]) {
-			const targetBit = 1n << BigInt(edge.targetLocal);
-			if ((mask & targetBit) === 0n) continue;
-
-			const rest = solve(withoutFirst & ~targetBit);
-			const candidateEdges = [...rest.edges, edge];
-			const candidate = {
-				count: rest.count + 1,
-				score: rest.score + edge.score,
-				edges: candidateEdges,
-				tieKey: pairTieKey(candidateEdges),
-			};
-
-			if (isBetterMatch(candidate, best)) best = candidate;
-		}
-
-		memo.set(mask, best);
-		return best;
+	const mate = blossom(localEdges, true);
+	const selected = [];
+	for (let local = 0; local < mate.length; local++) {
+		const mateLocal = mate[local];
+		if (mateLocal == null || mateLocal < 0 || local >= mateLocal) continue;
+		const edge = edgeByLocalPair.get(`${local}:${mateLocal}`);
+		if (edge) selected.push(edge);
 	}
 
-	return solve(fullMask);
+	return selected;
 }
 
 function hasLegalLeftoverEdge(leftovers, graphEdges, batch) {
@@ -185,38 +242,25 @@ function hasLegalLeftoverEdge(leftovers, graphEdges, batch) {
 }
 
 function selectGraphBatchPairings(batch, evaluatePairFn = evaluatePair, options = {}) {
-	const maxExactComponentVertices = options.maxExactComponentVertices ?? DEFAULT_MAX_EXACT_COMPONENT_VERTICES;
-	const graph = buildPairingGraph(batch, evaluatePairFn);
+	const graph = buildPairingGraph(batch, evaluatePairFn, options);
 	const components = connectedComponents(batch.length, graph.adjacency);
 	const pairings = [];
 	const matchedIndexes = new Set();
-	let usedFallback = false;
 	let totalPairingScore = 0;
+	let totalPairingCost = 0;
 
 	for (const component of components) {
 		if (component.length < 2) continue;
 
-		if (component.length > maxExactComponentVertices) {
-			usedFallback = true;
-			const componentBatch = component.map((index) => batch[index]);
-			const fallback = selectGreedyBatchPairings(componentBatch, evaluatePairFn);
-			for (const pairing of fallback.pairings) {
-				pairings.push(pairing);
-				matchedIndexes.add(batch.findIndex((player) => String(player._id) === String(pairing.white._id)));
-				matchedIndexes.add(batch.findIndex((player) => String(player._id) === String(pairing.black._id)));
-			}
-			totalPairingScore += fallback.totalPairingScore;
-			continue;
-		}
-
-		const solution = solveExactComponent(component, graph.adjacency);
-		const selectedEdges = [...solution.edges].sort((left, right) => Math.min(left.i, left.j) - Math.min(right.i, right.j));
+		const selectedEdges = solveBlossomComponent(component, graph.adjacency)
+			.sort((left, right) => Math.min(left.i, left.j) - Math.min(right.i, right.j));
 
 		for (const edge of selectedEdges) {
 			pairings.push(edge.colors);
 			matchedIndexes.add(edge.i);
 			matchedIndexes.add(edge.j);
 			totalPairingScore += edge.score;
+			totalPairingCost += edge.cost;
 		}
 	}
 
@@ -228,8 +272,9 @@ function selectGraphBatchPairings(batch, evaluatePairFn = evaluatePair, options 
 		leftovers,
 		exhaustedNoLegalPairPool,
 		strategy: 'graph',
-		usedFallback,
+		usedFallback: false,
 		totalPairingScore,
+		totalPairingCost: Number(totalPairingCost.toFixed(3)),
 		legalEdgeCount: graph.edges.length,
 	};
 }
@@ -241,4 +286,5 @@ module.exports = {
 	selectGraphBatchPairings,
 	selectGreedyBatchPairings,
 	buildPairingGraph,
+	pairingCost,
 };

--- a/backend/src/services/pairingService.js
+++ b/backend/src/services/pairingService.js
@@ -1,4 +1,5 @@
 const { PairingWorker } = require('./pairing/pairingWorker');
+const { parsePairingSettleMs } = require('./pairing/pairingConfig');
 const { redis, enqueue } = require('./queue/redisQueue');
 const Player = require('../models/Player');
 
@@ -7,7 +8,7 @@ class PairingService {
 		this.workers = new Map(); // tournamentId -> worker
 	}
 
-	async seedQueueOnStart(tournamentId) {
+	async seedQueueOnStart(tournamentId, { enqueuedAt = Date.now() } = {}) {
 		// Put all non-playing players into the queue (and set waitingSince)
 		const now = new Date();
 		const players = await Player.find({
@@ -33,7 +34,7 @@ class PairingService {
 				colorHistory: p.colorHistory ?? [],
 				status: p.status,
 				waitingSince: p.waitingSince ?? now,
-				enqueuedAt: Date.now(),
+				enqueuedAt,
 			});
 		}
 
@@ -54,11 +55,14 @@ class PairingService {
 			});
 		}
 
-		// seed queue with all non-playing players
-		await this.seedQueueOnStart(tournamentId);
+		const settleMs = parsePairingSettleMs();
+		// seed queue with all non-playing players. The initial pool is already
+		// complete, so mark it as settled instead of delaying round 1.
+		await this.seedQueueOnStart(tournamentId, { enqueuedAt: Date.now() - settleMs });
 
-		const worker = new PairingWorker({ workerId: `pair-${tournamentId}`, batchSize: 80, idleMs: 400 });
+		const worker = new PairingWorker({ workerId: `pair-${tournamentId}`, batchSize: 80, idleMs: 400, settleMs });
 		this.workers.set(String(tournamentId), worker);
+		console.log(`[pairing] Started worker for tournament ${tournamentId} with settleMs=${settleMs}.`);
 		// begin worker
 		worker.start(tournamentId);
 	}

--- a/backend/test-scripts/simulatePairingComparison.js
+++ b/backend/test-scripts/simulatePairingComparison.js
@@ -19,7 +19,7 @@ const {
 const DEFAULTS = {
 	players: 20,
 	seed: 20260519,
-	durationMinutes: 120,
+	durationMinutes: 60,
 	outputDir: path.join(__dirname, '..', 'test-output'),
 };
 
@@ -73,6 +73,10 @@ function asNumber(value, fallback = 0) {
 
 function minutes(ms) {
 	return Math.round(ms / 60000);
+}
+
+function roundMinutes(ms) {
+	return Number((ms / 60000).toFixed(2));
 }
 
 function formatClock(startMs, timestamp) {
@@ -155,10 +159,9 @@ function refreshStandings(players) {
 
 function buildLeaveSchedule(players, startMs, durationMs) {
 	const planned = [
-		{ index: 16, at: 42 },
-		{ index: 7, at: 67 },
-		{ index: 12, at: 86 },
-		{ index: 3, at: 104 },
+		{ index: 16, at: 32 },
+		{ index: 7, at: 47 },
+		{ index: 12, at: 57 },
 	];
 	return planned
 		.filter(({ index, at }) => index < players.length && at * 60000 < durationMs)
@@ -199,14 +202,18 @@ function applyPairing(white, black, now) {
 
 function gameDurationMs({ white, black, startMs, seed, gameNumber }) {
 	const roll = hashToUnit(seed, 'duration', white._id, black._id, Math.floor(startMs / 60000), gameNumber);
+	const jitter = hashToUnit(seed, 'duration-jitter', black._id, white._id, gameNumber);
+	const ratingGap = Math.abs((white.liveRating ?? white.entryRating) - (black.liveRating ?? black.entryRating));
+	const mismatchShortcut = Math.min(ratingGap / 1200, 0.35);
 	let durationMinutes;
-	if (roll < 0.12) durationMinutes = 8 + Math.floor(roll * 30);
-	else if (roll < 0.32) durationMinutes = 15;
-	else if (roll < 0.5) durationMinutes = 22;
-	else if (roll < 0.68) durationMinutes = 30;
-	else durationMinutes = 34 + Math.floor(roll * 18);
 
-	return durationMinutes * 60000;
+	if (roll < 0.08) durationMinutes = 1.8 + jitter * 1.2;
+	else if (roll < 0.36) durationMinutes = 3 + jitter * 2.2;
+	else if (roll < 0.76) durationMinutes = 5.2 + jitter * 2.6;
+	else durationMinutes = 7.8 + jitter * 2.45;
+
+	durationMinutes = clamp(durationMinutes - mismatchShortcut, 1.5, 10.25);
+	return Math.round(durationMinutes * 60000);
 }
 
 function scoreResult(white, black, seed, gameNumber) {
@@ -305,6 +312,7 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 		const timeline = [];
 		const cycles = [];
 		const waitSamples = [];
+		const waitRecords = [];
 		const metrics = {
 			gamesStarted: 0,
 			gamesCompleted: 0,
@@ -451,12 +459,16 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 				activeGames.set(gameId, game);
 				scheduleEvent({ type: 'finish', time: game.finishTime, gameId });
 				metrics.gamesStarted += 1;
+				waitRecords.push(
+					{ playerId: white._id, gameId, waitMinutes: roundMinutes(whiteWaitMs), pairedAt: formatClock(startMs, now) },
+					{ playerId: black._id, gameId, waitMinutes: roundMinutes(blackWaitMs), pairedAt: formatClock(startMs, now) },
+				);
 
 				pairLog.push({
 					gameId,
 					whiteId: white._id,
 					blackId: black._id,
-					durationMinutes: minutes(duration),
+					durationMinutes: roundMinutes(duration),
 					resultColor,
 					priorMeetings: validation.priorMeetings,
 					violations: validation.violations,
@@ -511,17 +523,35 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 		const avgWaitMinutes = waitSamples.length
 			? waitSamples.reduce((sum, value) => sum + value, 0) / waitSamples.length / 60000
 			: 0;
+		const maxWaitMinutes = waitSamples.length
+			? Math.max(...waitSamples) / 60000
+			: 0;
+		const activeWaitingAtEnd = waitingQueue
+			.map((id) => playersById.get(id))
+			.filter((player) => player?.status === 'active' && player.waitingSince)
+			.map((player) => ({
+				playerId: player._id,
+				waitMinutes: roundMinutes(startMs + durationMs - new Date(player.waitingSince).getTime()),
+			}))
+			.sort((left, right) => right.waitMinutes - left.waitMinutes);
 
 		return {
 			name,
 			metrics: {
 				...metrics,
 				avgWaitMinutes: Number(avgWaitMinutes.toFixed(2)),
+				maxWaitMinutes: Number(maxWaitMinutes.toFixed(2)),
+				waitsOver5Minutes: waitRecords.filter((record) => record.waitMinutes > 5).length,
+				waitsOver8Minutes: waitRecords.filter((record) => record.waitMinutes > 8).length,
 				playersStillWaiting: waitingQueue.length,
 				activeGamesAtEnd: activeGames.size,
 			},
 			cycles,
 			timeline,
+			longestWaits: [...waitRecords]
+				.sort((left, right) => right.waitMinutes - left.waitMinutes)
+				.slice(0, 12),
+			activeWaitingAtEnd,
 			finalStandings: refreshStandings(players).map(summarizePlayer),
 		};
 	} finally {
@@ -554,6 +584,9 @@ function renderHtml(report) {
 			<td>${m.ruleViolations}</td>
 			<td>${m.engineWarnings}</td>
 			<td>${m.avgWaitMinutes}</td>
+			<td>${m.maxWaitMinutes}</td>
+			<td>${m.waitsOver5Minutes}</td>
+			<td>${m.waitsOver8Minutes}</td>
 		</tr>`;
 	}).join('');
 
@@ -603,6 +636,27 @@ function renderHtml(report) {
 		</section>`;
 	}).join('');
 
+	const waitTables = report.results.map((result) => {
+		const rows = result.longestWaits.map((record) => `<tr>
+			<td>${escapeHtml(record.playerId)}</td>
+			<td>${escapeHtml(record.gameId)}</td>
+			<td>${record.waitMinutes}</td>
+			<td>${escapeHtml(record.pairedAt)}</td>
+		</tr>`).join('');
+		const endRows = result.activeWaitingAtEnd.map((record) => `<tr>
+			<td>${escapeHtml(record.playerId)}</td>
+			<td>${record.waitMinutes}</td>
+		</tr>`).join('');
+		return `<section>
+			<h2>${escapeHtml(result.name)} longest waits</h2>
+			<table>
+				<thead><tr><th>Player</th><th>Game</th><th>Wait minutes</th><th>Paired at</th></tr></thead>
+				<tbody>${rows}</tbody>
+			</table>
+			${endRows ? `<h2>${escapeHtml(result.name)} waiting at time control</h2><table><thead><tr><th>Player</th><th>Wait minutes</th></tr></thead><tbody>${endRows}</tbody></table>` : ''}
+		</section>`;
+	}).join('');
+
 	const eventRows = report.results.map((result) => {
 		const rows = result.timeline.slice(0, 160).map((event) => `<tr>
 			<td>${event.time}</td>
@@ -637,12 +691,12 @@ function renderHtml(report) {
 <body>
 	<main>
 		<h1>Pairing Algorithm Comparison</h1>
-		<p>Scenario: ${report.scenario.players} players, ${report.scenario.durationMinutes} minutes, fixed leave schedule, asynchronous game finishes, seed <code>${report.scenario.seed}</code>.</p>
+		<p>Scenario: ${report.scenario.players} players, ${report.scenario.durationMinutes} minutes, ${escapeHtml(report.scenario.timeControl)}, varied game durations capped near 10 minutes, fixed leave schedule, asynchronous game finishes, seed <code>${report.scenario.seed}</code>.</p>
 		<section class="grid">
 			<div class="panel">
 				<h2>Summary</h2>
 				<table>
-					<thead><tr><th>Algorithm</th><th>Started</th><th>Completed</th><th>Cancelled</th><th>Stalled</th><th>Rule violations</th><th>Warnings</th><th>Avg wait</th></tr></thead>
+					<thead><tr><th>Algorithm</th><th>Started</th><th>Completed</th><th>Cancelled</th><th>Stalled</th><th>Rule violations</th><th>Warnings</th><th>Avg wait</th><th>Max wait</th><th>&gt;5m</th><th>&gt;8m</th></tr></thead>
 					<tbody>${rows}</tbody>
 				</table>
 			</div>
@@ -652,6 +706,7 @@ function renderHtml(report) {
 			</div>
 		</section>
 		${cycleTables}
+		${waitTables}
 		${standings}
 		<section>
 			<h2>Timeline Sample</h2>
@@ -674,6 +729,12 @@ function runComparison(options) {
 		players: options.players,
 		seed: options.seed,
 		durationMinutes: options.durationMinutes,
+		timeControl: '3+2 blitz',
+		gameDurationModel: {
+			minMinutes: 1.5,
+			maxMinutes: 10.25,
+			description: 'Piecewise deterministic random distribution with short games, a middle mass around 5-8 minutes, and a long tail near the 3+2 maximum.',
+		},
 		rules: {
 			maxColorStreak: MAX_COLOR_STREAK,
 			maxColorImbalance: MAX_COLOR_IMBALANCE,
@@ -731,7 +792,8 @@ try {
 			`${result.name}: started=${result.metrics.gamesStarted} completed=${result.metrics.gamesCompleted} `
 			+ `cancelled=${result.metrics.gamesCancelled} stalled=${result.metrics.stalledPoolEvents} `
 			+ `violations=${result.metrics.ruleViolations} warnings=${result.metrics.engineWarnings} `
-			+ `avgWaitMinutes=${result.metrics.avgWaitMinutes}`
+			+ `avgWaitMinutes=${result.metrics.avgWaitMinutes} maxWaitMinutes=${result.metrics.maxWaitMinutes} `
+			+ `waitsOver5=${result.metrics.waitsOver5Minutes} waitsOver8=${result.metrics.waitsOver8Minutes}`
 		);
 	}
 	console.log(`json=${outputs.jsonPath}`);

--- a/backend/test-scripts/simulatePairingComparison.js
+++ b/backend/test-scripts/simulatePairingComparison.js
@@ -773,8 +773,9 @@ function runComparison(options) {
 
 function writeOutputs(report, outputDir) {
 	fs.mkdirSync(outputDir, { recursive: true });
-	const jsonPath = path.join(outputDir, 'pairing-comparison-20p.json');
-	const htmlPath = path.join(outputDir, 'pairing-comparison-20p.html');
+	const prefix = `pairing-comparison-${report.scenario.players}p-${report.scenario.durationMinutes}m`;
+	const jsonPath = path.join(outputDir, `${prefix}.json`);
+	const htmlPath = path.join(outputDir, `${prefix}.html`);
 	fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
 	fs.writeFileSync(htmlPath, renderHtml(report));
 	return { jsonPath, htmlPath };

--- a/backend/test-scripts/simulatePairingComparison.js
+++ b/backend/test-scripts/simulatePairingComparison.js
@@ -20,6 +20,7 @@ const DEFAULTS = {
 	players: 20,
 	seed: 20260519,
 	durationMinutes: 60,
+	settleSeconds: 30,
 	outputDir: path.join(__dirname, '..', 'test-output'),
 };
 
@@ -30,7 +31,7 @@ function parseArgs(argv) {
 		if (!arg.startsWith('--')) continue;
 		const key = arg.slice(2);
 		const next = argv[i + 1];
-		if (['players', 'seed', 'durationMinutes'].includes(key)) {
+		if (['players', 'seed', 'durationMinutes', 'settleSeconds'].includes(key)) {
 			const value = Number(next);
 			if (!Number.isFinite(value)) throw new Error(`Invalid numeric value for --${key}: ${next}`);
 			opts[key] = value;
@@ -297,7 +298,7 @@ function summarizePlayer(player) {
 	};
 }
 
-function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, startMs, durationMs }) {
+function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, startMs, durationMs, settleMs }) {
 	const originalDateNow = Date.now;
 	let now = startMs;
 	Date.now = () => now;
@@ -313,6 +314,8 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 		const cycles = [];
 		const waitSamples = [];
 		const waitRecords = [];
+		const frontierSamples = [];
+		let scheduledPairingAt = null;
 		const metrics = {
 			gamesStarted: 0,
 			gamesCompleted: 0,
@@ -332,6 +335,7 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 			if (waitingQueue.includes(player._id)) return;
 			if (!player.waitingSince) player.waitingSince = new Date(now);
 			waitingQueue.push(player._id);
+			requestPairingCycle();
 		}
 
 		function removeFromQueue(playerId) {
@@ -342,9 +346,15 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 			events.push(event);
 			events.sort((left, right) => {
 				if (left.time !== right.time) return left.time - right.time;
-				const order = { finish: 0, leave: 1 };
+				const order = { finish: 0, leave: 1, pair: 2 };
 				return (order[left.type] ?? 9) - (order[right.type] ?? 9);
 			});
+		}
+
+		function requestPairingCycle() {
+			const pairingAt = now + settleMs;
+			scheduledPairingAt = pairingAt;
+			scheduleEvent({ type: 'pair', time: pairingAt });
 		}
 
 		function finishGame(gameId) {
@@ -422,6 +432,7 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 
 			const candidates = waitingQueue.map((id) => playersById.get(id));
 			if (candidates.length < 2) return;
+			frontierSamples.push(candidates.length);
 
 			const result = selector(candidates, evaluatePair, { maxExactComponentVertices: 24 });
 			const used = new Set();
@@ -515,8 +526,11 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 			for (const event of simultaneous.filter((item) => item.type === 'leave')) {
 				pausePlayer(event.playerId, event.reason);
 			}
-
-			runPairingCycle(`after ${simultaneous.map((event) => event.type).join('+')}`);
+			for (const event of simultaneous.filter((item) => item.type === 'pair')) {
+				if (scheduledPairingAt !== event.time) continue;
+				scheduledPairingAt = null;
+				runPairingCycle(`settled ${settleMs / 1000}s`);
+			}
 		}
 
 		refreshStandings(players);
@@ -534,6 +548,9 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 				waitMinutes: roundMinutes(startMs + durationMs - new Date(player.waitingSince).getTime()),
 			}))
 			.sort((left, right) => right.waitMinutes - left.waitMinutes);
+		const avgPairingPoolSize = frontierSamples.length
+			? frontierSamples.reduce((sum, value) => sum + value, 0) / frontierSamples.length
+			: 0;
 
 		return {
 			name,
@@ -543,6 +560,10 @@ function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, s
 				maxWaitMinutes: Number(maxWaitMinutes.toFixed(2)),
 				waitsOver5Minutes: waitRecords.filter((record) => record.waitMinutes > 5).length,
 				waitsOver8Minutes: waitRecords.filter((record) => record.waitMinutes > 8).length,
+				maxPairingPoolSize: frontierSamples.length ? Math.max(...frontierSamples) : 0,
+				avgPairingPoolSize: Number(avgPairingPoolSize.toFixed(2)),
+				cyclesWithPoolAtLeast6: frontierSamples.filter((value) => value >= 6).length,
+				cyclesWithPoolAtLeast10: frontierSamples.filter((value) => value >= 10).length,
 				playersStillWaiting: waitingQueue.length,
 				activeGamesAtEnd: activeGames.size,
 			},
@@ -587,6 +608,9 @@ function renderHtml(report) {
 			<td>${m.maxWaitMinutes}</td>
 			<td>${m.waitsOver5Minutes}</td>
 			<td>${m.waitsOver8Minutes}</td>
+			<td>${m.avgPairingPoolSize}</td>
+			<td>${m.maxPairingPoolSize}</td>
+			<td>${m.cyclesWithPoolAtLeast6}</td>
 		</tr>`;
 	}).join('');
 
@@ -691,12 +715,12 @@ function renderHtml(report) {
 <body>
 	<main>
 		<h1>Pairing Algorithm Comparison</h1>
-		<p>Scenario: ${report.scenario.players} players, ${report.scenario.durationMinutes} minutes, ${escapeHtml(report.scenario.timeControl)}, varied game durations capped near 10 minutes, fixed leave schedule, asynchronous game finishes, seed <code>${report.scenario.seed}</code>.</p>
+		<p>Scenario: ${report.scenario.players} players, ${report.scenario.durationMinutes} minutes, ${escapeHtml(report.scenario.timeControl)}, ${report.scenario.settleSeconds}s settle window, varied game durations capped near 10 minutes, fixed leave schedule, asynchronous game finishes, seed <code>${report.scenario.seed}</code>.</p>
 		<section class="grid">
 			<div class="panel">
 				<h2>Summary</h2>
 				<table>
-					<thead><tr><th>Algorithm</th><th>Started</th><th>Completed</th><th>Cancelled</th><th>Stalled</th><th>Rule violations</th><th>Warnings</th><th>Avg wait</th><th>Max wait</th><th>&gt;5m</th><th>&gt;8m</th></tr></thead>
+					<thead><tr><th>Algorithm</th><th>Started</th><th>Completed</th><th>Cancelled</th><th>Stalled</th><th>Rule violations</th><th>Warnings</th><th>Avg wait</th><th>Max wait</th><th>&gt;5m</th><th>&gt;8m</th><th>Avg pool</th><th>Max pool</th><th>Pool >=6</th></tr></thead>
 					<tbody>${rows}</tbody>
 				</table>
 			</div>
@@ -729,6 +753,7 @@ function runComparison(options) {
 		players: options.players,
 		seed: options.seed,
 		durationMinutes: options.durationMinutes,
+		settleSeconds: options.settleSeconds,
 		timeControl: '3+2 blitz',
 		gameDurationModel: {
 			minMinutes: 1.5,
@@ -756,6 +781,7 @@ function runComparison(options) {
 			seed: options.seed,
 			startMs,
 			durationMs,
+			settleMs: options.settleSeconds * 1000,
 		}),
 		simulateAlgorithm({
 			name: 'graph-matching',
@@ -765,6 +791,7 @@ function runComparison(options) {
 			seed: options.seed,
 			startMs,
 			durationMs,
+			settleMs: options.settleSeconds * 1000,
 		}),
 	];
 
@@ -773,7 +800,7 @@ function runComparison(options) {
 
 function writeOutputs(report, outputDir) {
 	fs.mkdirSync(outputDir, { recursive: true });
-	const prefix = `pairing-comparison-${report.scenario.players}p-${report.scenario.durationMinutes}m`;
+	const prefix = `pairing-comparison-${report.scenario.players}p-${report.scenario.durationMinutes}m-${report.scenario.settleSeconds}s-settle`;
 	const jsonPath = path.join(outputDir, `${prefix}.json`);
 	const htmlPath = path.join(outputDir, `${prefix}.html`);
 	fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
@@ -787,14 +814,15 @@ try {
 	const outputs = writeOutputs(report, options.outputDir);
 
 	console.log('Pairing comparison simulation');
-	console.log(`players=${options.players} durationMinutes=${options.durationMinutes} seed=${options.seed}`);
+	console.log(`players=${options.players} durationMinutes=${options.durationMinutes} settleSeconds=${options.settleSeconds} seed=${options.seed}`);
 	for (const result of report.results) {
 		console.log(
 			`${result.name}: started=${result.metrics.gamesStarted} completed=${result.metrics.gamesCompleted} `
 			+ `cancelled=${result.metrics.gamesCancelled} stalled=${result.metrics.stalledPoolEvents} `
 			+ `violations=${result.metrics.ruleViolations} warnings=${result.metrics.engineWarnings} `
 			+ `avgWaitMinutes=${result.metrics.avgWaitMinutes} maxWaitMinutes=${result.metrics.maxWaitMinutes} `
-			+ `waitsOver5=${result.metrics.waitsOver5Minutes} waitsOver8=${result.metrics.waitsOver8Minutes}`
+			+ `waitsOver5=${result.metrics.waitsOver5Minutes} waitsOver8=${result.metrics.waitsOver8Minutes} `
+			+ `avgPool=${result.metrics.avgPairingPoolSize} maxPool=${result.metrics.maxPairingPoolSize}`
 		);
 	}
 	console.log(`json=${outputs.jsonPath}`);

--- a/backend/test-scripts/simulatePairingComparison.js
+++ b/backend/test-scripts/simulatePairingComparison.js
@@ -808,27 +808,41 @@ function writeOutputs(report, outputDir) {
 	return { jsonPath, htmlPath };
 }
 
-try {
-	const options = parseArgs(process.argv.slice(2));
-	const report = runComparison(options);
-	const outputs = writeOutputs(report, options.outputDir);
+function runCli() {
+	try {
+		const options = parseArgs(process.argv.slice(2));
+		const report = runComparison(options);
+		const outputs = writeOutputs(report, options.outputDir);
 
-	console.log('Pairing comparison simulation');
-	console.log(`players=${options.players} durationMinutes=${options.durationMinutes} settleSeconds=${options.settleSeconds} seed=${options.seed}`);
-	for (const result of report.results) {
-		console.log(
-			`${result.name}: started=${result.metrics.gamesStarted} completed=${result.metrics.gamesCompleted} `
-			+ `cancelled=${result.metrics.gamesCancelled} stalled=${result.metrics.stalledPoolEvents} `
-			+ `violations=${result.metrics.ruleViolations} warnings=${result.metrics.engineWarnings} `
-			+ `avgWaitMinutes=${result.metrics.avgWaitMinutes} maxWaitMinutes=${result.metrics.maxWaitMinutes} `
-			+ `waitsOver5=${result.metrics.waitsOver5Minutes} waitsOver8=${result.metrics.waitsOver8Minutes} `
-			+ `avgPool=${result.metrics.avgPairingPoolSize} maxPool=${result.metrics.maxPairingPoolSize}`
-		);
+		console.log('Pairing comparison simulation');
+		console.log(`players=${options.players} durationMinutes=${options.durationMinutes} settleSeconds=${options.settleSeconds} seed=${options.seed}`);
+		for (const result of report.results) {
+			console.log(
+				`${result.name}: started=${result.metrics.gamesStarted} completed=${result.metrics.gamesCompleted} `
+				+ `cancelled=${result.metrics.gamesCancelled} stalled=${result.metrics.stalledPoolEvents} `
+				+ `violations=${result.metrics.ruleViolations} warnings=${result.metrics.engineWarnings} `
+				+ `avgWaitMinutes=${result.metrics.avgWaitMinutes} maxWaitMinutes=${result.metrics.maxWaitMinutes} `
+				+ `waitsOver5=${result.metrics.waitsOver5Minutes} waitsOver8=${result.metrics.waitsOver8Minutes} `
+				+ `avgPool=${result.metrics.avgPairingPoolSize} maxPool=${result.metrics.maxPairingPoolSize}`
+			);
+		}
+		console.log(`json=${outputs.jsonPath}`);
+		console.log(`html=${outputs.htmlPath}`);
+		process.exit(report.results.every((result) => result.metrics.ruleViolations === 0 && result.metrics.engineWarnings === 0) ? 0 : 1);
+	} catch (error) {
+		console.error(error.stack || error.message);
+		process.exit(1);
 	}
-	console.log(`json=${outputs.jsonPath}`);
-	console.log(`html=${outputs.htmlPath}`);
-	process.exit(report.results.every((result) => result.metrics.ruleViolations === 0 && result.metrics.engineWarnings === 0) ? 0 : 1);
-} catch (error) {
-	console.error(error.stack || error.message);
-	process.exit(1);
 }
+
+if (require.main === module) {
+	runCli();
+}
+
+module.exports = {
+	DEFAULTS,
+	parseArgs,
+	runComparison,
+	writeOutputs,
+	renderHtml,
+};

--- a/backend/test-scripts/simulatePairingComparison.js
+++ b/backend/test-scripts/simulatePairingComparison.js
@@ -1,0 +1,743 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+	evaluatePair,
+	justPlayedTogether,
+	lastColorVsOpponent,
+	tooManyHeadToHead,
+	wouldExceedColorLimit,
+	wouldExceedImbalanceLimit,
+	MAX_COLOR_STREAK,
+	MAX_COLOR_IMBALANCE,
+} = require('../src/services/pairing/pairingScorer');
+const {
+	selectGreedyBatchPairings,
+	selectGraphBatchPairings,
+} = require('../src/services/pairing/selectBatchPairings');
+
+const DEFAULTS = {
+	players: 20,
+	seed: 20260519,
+	durationMinutes: 120,
+	outputDir: path.join(__dirname, '..', 'test-output'),
+};
+
+function parseArgs(argv) {
+	const opts = { ...DEFAULTS };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (!arg.startsWith('--')) continue;
+		const key = arg.slice(2);
+		const next = argv[i + 1];
+		if (['players', 'seed', 'durationMinutes'].includes(key)) {
+			const value = Number(next);
+			if (!Number.isFinite(value)) throw new Error(`Invalid numeric value for --${key}: ${next}`);
+			opts[key] = value;
+			i += 1;
+		} else if (key === 'outputDir') {
+			opts.outputDir = next;
+			i += 1;
+		}
+	}
+	return opts;
+}
+
+function mulberry32(seed) {
+	let t = seed >>> 0;
+	return function rng() {
+		t += 0x6D2B79F5;
+		let x = Math.imul(t ^ (t >>> 15), t | 1);
+		x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+		return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function hashToUnit(...parts) {
+	let h = 2166136261;
+	for (const part of parts.join('|')) {
+		h ^= part.charCodeAt(0);
+		h = Math.imul(h, 16777619);
+	}
+	return (h >>> 0) / 4294967296;
+}
+
+function clamp(value, min, max) {
+	return Math.min(Math.max(value, min), max);
+}
+
+function asNumber(value, fallback = 0) {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function minutes(ms) {
+	return Math.round(ms / 60000);
+}
+
+function formatClock(startMs, timestamp) {
+	const total = minutes(timestamp - startMs);
+	const h = Math.floor(total / 60);
+	const m = total % 60;
+	return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function calculatePerformanceRating({ sumOpponentRatings = 0, gamesPlayed = 0, score = 0 }) {
+	const games = asNumber(gamesPlayed, 0);
+	if (!games) return 0;
+	const points = asNumber(score, 0);
+	let avgOpp = sumOpponentRatings / games;
+	if (!Number.isFinite(avgOpp)) avgOpp = 0;
+
+	const effectiveAvgOpp = Math.max(avgOpp, 1400);
+	const fraction = points / games;
+
+	if (fraction >= 1) return Math.round(effectiveAvgOpp + 400);
+	if (fraction <= 0) return Math.round(Math.max(effectiveAvgOpp - 400, 0));
+
+	const diff = clamp(400 * Math.log10(fraction / (1 - fraction)), -400, 400);
+	return Math.round(Math.max(effectiveAvgOpp + diff, 0));
+}
+
+function createPlayers(count, seed, startMs) {
+	const rng = mulberry32(seed);
+	const firstNames = [
+		'Alex', 'Maria', 'Nikos', 'Eleni', 'Iris', 'Dimitris', 'Sofia', 'Petros', 'Danae', 'Kostas',
+		'Anna', 'Marios', 'Stella', 'Giorgos', 'Mina', 'Theo', 'Lina', 'Aris', 'Chloe', 'Panos',
+	];
+
+	return Array.from({ length: count }, (_, index) => {
+		const band = index < 4 ? 1750 + rng() * 320 : index < 14 ? 1250 + rng() * 430 : 850 + rng() * 360;
+		const rating = Math.round(band);
+		return {
+			_id: `P${String(index + 1).padStart(2, '0')}`,
+			name: firstNames[index % firstNames.length],
+			score: 0,
+			liveRating: rating,
+			entryRating: rating,
+			standing: null,
+			recentOpponents: [],
+			colorHistory: [],
+			waitingSince: new Date(startMs),
+			status: 'active',
+			isPlaying: false,
+			gamesPlayed: 0,
+			wins: 0,
+			draws: 0,
+			losses: 0,
+			sumOpponentRatings: 0,
+			gameHistory: [],
+		};
+	});
+}
+
+function clonePlayers(players) {
+	return players.map((player) => ({
+		...player,
+		recentOpponents: [...player.recentOpponents],
+		colorHistory: [...player.colorHistory],
+		gameHistory: [...player.gameHistory],
+		waitingSince: player.waitingSince ? new Date(player.waitingSince) : null,
+	}));
+}
+
+function refreshStandings(players) {
+	const sorted = [...players].sort((left, right) => {
+		if (right.score !== left.score) return right.score - left.score;
+		if (right.liveRating !== left.liveRating) return right.liveRating - left.liveRating;
+		return left._id.localeCompare(right._id);
+	});
+	sorted.forEach((player, index) => {
+		player.standing = index + 1;
+	});
+	return sorted;
+}
+
+function buildLeaveSchedule(players, startMs, durationMs) {
+	const planned = [
+		{ index: 16, at: 42 },
+		{ index: 7, at: 67 },
+		{ index: 12, at: 86 },
+		{ index: 3, at: 104 },
+	];
+	return planned
+		.filter(({ index, at }) => index < players.length && at * 60000 < durationMs)
+		.map(({ index, at }) => ({
+			type: 'leave',
+			time: startMs + at * 60000,
+			playerId: players[index]._id,
+			reason: 'early_exit',
+		}));
+}
+
+function colorFor(player, game) {
+	return String(game.whiteId) === String(player._id) ? 'white' : 'black';
+}
+
+function rollbackLatestPairingHistory(player, opponentId, expectedColor) {
+	const opponents = [...(player.recentOpponents ?? [])];
+	const colors = [...(player.colorHistory ?? [])];
+	if (!opponents.length || !colors.length) return;
+	if (String(opponents.at(-1)) !== String(opponentId) || colors.at(-1) !== expectedColor) return;
+
+	player.recentOpponents = opponents.slice(0, -1);
+	player.colorHistory = colors.slice(0, -1);
+}
+
+function applyPairing(white, black, now) {
+	white.isPlaying = true;
+	black.isPlaying = true;
+	white.waitingSince = null;
+	black.waitingSince = null;
+	white.colorHistory = [...white.colorHistory, 'white'].slice(-10);
+	black.colorHistory = [...black.colorHistory, 'black'].slice(-10);
+	white.recentOpponents = [...white.recentOpponents, black._id].slice(-10);
+	black.recentOpponents = [...black.recentOpponents, white._id].slice(-10);
+	white.lastPairedAt = new Date(now);
+	black.lastPairedAt = new Date(now);
+}
+
+function gameDurationMs({ white, black, startMs, seed, gameNumber }) {
+	const roll = hashToUnit(seed, 'duration', white._id, black._id, Math.floor(startMs / 60000), gameNumber);
+	let durationMinutes;
+	if (roll < 0.12) durationMinutes = 8 + Math.floor(roll * 30);
+	else if (roll < 0.32) durationMinutes = 15;
+	else if (roll < 0.5) durationMinutes = 22;
+	else if (roll < 0.68) durationMinutes = 30;
+	else durationMinutes = 34 + Math.floor(roll * 18);
+
+	return durationMinutes * 60000;
+}
+
+function scoreResult(white, black, seed, gameNumber) {
+	const expectedWhite = 1 / (1 + 10 ** ((black.liveRating - white.liveRating) / 400));
+	const diff = white.liveRating - black.liveRating;
+	const drawProb = clamp(0.16 + 0.24 * Math.exp(-Math.abs(diff) / 250), 0.14, 0.4);
+	const decisiveProb = 1 - drawProb;
+	const whiteProb = decisiveProb * expectedWhite;
+	const roll = hashToUnit(seed, 'result', white._id, black._id, gameNumber);
+
+	if (roll < drawProb) return 'draw';
+	if (roll < drawProb + whiteProb) return 'white';
+	return 'black';
+}
+
+function applyResultToPlayer({ player, opponentRating, resultColor, perspective, gameId, now }) {
+	const isWhite = perspective === 'white';
+	const resultMap = {
+		white: isWhite ? 1 : 0,
+		black: isWhite ? 0 : 1,
+		draw: 0.5,
+	};
+	const points = resultMap[resultColor] ?? 0;
+
+	player.isPlaying = false;
+	player.gamesPlayed += 1;
+	player.score += points;
+	player.gameHistory = [...player.gameHistory, gameId].slice(-50);
+	player.sumOpponentRatings += opponentRating;
+	player.lastResultAt = new Date(now);
+
+	if (resultColor === 'draw') player.draws += 1;
+	else if ((resultColor === 'white' && isWhite) || (resultColor === 'black' && !isWhite)) player.wins += 1;
+	else player.losses += 1;
+
+	player.liveRating = calculatePerformanceRating({
+		sumOpponentRatings: player.sumOpponentRatings,
+		gamesPlayed: player.gamesPlayed,
+		score: player.score,
+	});
+}
+
+function headToHeadCount(a, b) {
+	const bId = String(b._id);
+	return (a.recentOpponents ?? []).filter((opp) => String(opp) === bId).length;
+}
+
+function validatePairing(whiteBefore, blackBefore) {
+	const priorMeetings = Math.max(headToHeadCount(whiteBefore, blackBefore), headToHeadCount(blackBefore, whiteBefore));
+	const lastWhiteColorVsBlack = lastColorVsOpponent(whiteBefore, blackBefore);
+	const checks = {
+		noImmediateRematch: !justPlayedTogether(whiteBefore, blackBefore),
+		maxMeetings: !tooManyHeadToHead(whiteBefore, blackBefore),
+		rematchColorSwap: lastWhiteColorVsBlack === null ? null : lastWhiteColorVsBlack !== 'white',
+		whiteStreakLimit: !wouldExceedColorLimit(whiteBefore, 'white'),
+		blackStreakLimit: !wouldExceedColorLimit(blackBefore, 'black'),
+		whiteImbalanceLimit: !wouldExceedImbalanceLimit(whiteBefore, 'white'),
+		blackImbalanceLimit: !wouldExceedImbalanceLimit(blackBefore, 'black'),
+	};
+
+	return {
+		priorMeetings,
+		violations: Object.entries(checks)
+			.filter(([, passed]) => passed === false)
+			.map(([name]) => name),
+	};
+}
+
+function summarizePlayer(player) {
+	return {
+		id: player._id,
+		name: player.name,
+		status: player.status,
+		score: Number(player.score.toFixed(1)),
+		liveRating: player.liveRating,
+		gamesPlayed: player.gamesPlayed,
+		wins: player.wins,
+		draws: player.draws,
+		losses: player.losses,
+		colors: player.colorHistory.map((color) => color[0].toUpperCase()).join(''),
+	};
+}
+
+function simulateAlgorithm({ name, selector, basePlayers, leaveSchedule, seed, startMs, durationMs }) {
+	const originalDateNow = Date.now;
+	let now = startMs;
+	Date.now = () => now;
+
+	try {
+		const players = clonePlayers(basePlayers);
+		const playersById = new Map(players.map((player) => [player._id, player]));
+		let waitingQueue = players.map((player) => player._id);
+		let gameCounter = 0;
+		const activeGames = new Map();
+		const events = leaveSchedule.map((event) => ({ ...event }));
+		const timeline = [];
+		const cycles = [];
+		const waitSamples = [];
+		const metrics = {
+			gamesStarted: 0,
+			gamesCompleted: 0,
+			gamesCancelled: 0,
+			ruleViolations: 0,
+			engineWarnings: 0,
+			stalledPoolEvents: 0,
+			usedFallbackCycles: 0,
+		};
+
+		function log(type, message, extra = {}) {
+			timeline.push({ time: formatClock(startMs, now), type, message, ...extra });
+		}
+
+		function enqueuePlayer(player) {
+			if (!player || player.status !== 'active' || player.isPlaying) return;
+			if (waitingQueue.includes(player._id)) return;
+			if (!player.waitingSince) player.waitingSince = new Date(now);
+			waitingQueue.push(player._id);
+		}
+
+		function removeFromQueue(playerId) {
+			waitingQueue = waitingQueue.filter((id) => String(id) !== String(playerId));
+		}
+
+		function scheduleEvent(event) {
+			events.push(event);
+			events.sort((left, right) => {
+				if (left.time !== right.time) return left.time - right.time;
+				const order = { finish: 0, leave: 1 };
+				return (order[left.type] ?? 9) - (order[right.type] ?? 9);
+			});
+		}
+
+		function finishGame(gameId) {
+			const game = activeGames.get(gameId);
+			if (!game || game.status !== 'active') return;
+
+			const white = playersById.get(game.whiteId);
+			const black = playersById.get(game.blackId);
+			activeGames.delete(gameId);
+			game.status = 'finished';
+
+			applyResultToPlayer({
+				player: white,
+				opponentRating: game.blackStartRating,
+				resultColor: game.resultColor,
+				perspective: 'white',
+				gameId,
+				now,
+			});
+			applyResultToPlayer({
+				player: black,
+				opponentRating: game.whiteStartRating,
+				resultColor: game.resultColor,
+				perspective: 'black',
+				gameId,
+				now,
+			});
+
+			metrics.gamesCompleted += 1;
+			log('finish', `${gameId}: ${white._id} vs ${black._id} result ${game.resultColor}`);
+			enqueuePlayer(white);
+			enqueuePlayer(black);
+		}
+
+		function pausePlayer(playerId, reason) {
+			const player = playersById.get(playerId);
+			if (!player || player.status !== 'active') return;
+
+			player.status = 'paused';
+			removeFromQueue(playerId);
+
+			const activeGame = [...activeGames.values()].find((game) => (
+				game.status === 'active' && (game.whiteId === playerId || game.blackId === playerId)
+			));
+
+			if (!activeGame) {
+				player.waitingSince = null;
+				log('pause', `${playerId} paused while waiting`, { reason });
+				return;
+			}
+
+			const opponentId = activeGame.whiteId === playerId ? activeGame.blackId : activeGame.whiteId;
+			const opponent = playersById.get(opponentId);
+			activeGame.status = 'cancelled';
+			activeGames.delete(activeGame.id);
+
+			rollbackLatestPairingHistory(player, opponentId, colorFor(player, activeGame));
+			rollbackLatestPairingHistory(opponent, playerId, colorFor(opponent, activeGame));
+
+			player.isPlaying = false;
+			player.waitingSince = null;
+			opponent.isPlaying = false;
+			opponent.waitingSince = new Date(now);
+			metrics.gamesCancelled += 1;
+			log('pause', `${playerId} paused mid-game; cancelled ${activeGame.id} vs ${opponentId}`, { reason });
+			enqueuePlayer(opponent);
+		}
+
+		function runPairingCycle(label) {
+			refreshStandings(players);
+			waitingQueue = waitingQueue.filter((id) => {
+				const player = playersById.get(id);
+				return player && player.status === 'active' && !player.isPlaying;
+			});
+
+			const candidates = waitingQueue.map((id) => playersById.get(id));
+			if (candidates.length < 2) return;
+
+			const result = selector(candidates, evaluatePair, { maxExactComponentVertices: 24 });
+			const used = new Set();
+			const pairLog = [];
+
+			for (const { white, black } of result.pairings) {
+				const whiteBefore = { ...white, recentOpponents: [...white.recentOpponents], colorHistory: [...white.colorHistory] };
+				const blackBefore = { ...black, recentOpponents: [...black.recentOpponents], colorHistory: [...black.colorHistory] };
+				const validation = validatePairing(whiteBefore, blackBefore);
+				if (validation.violations.length) metrics.ruleViolations += validation.violations.length;
+				if (used.has(white._id) || used.has(black._id)) metrics.engineWarnings += 1;
+				used.add(white._id);
+				used.add(black._id);
+
+				const whiteWaitMs = white.waitingSince ? now - new Date(white.waitingSince).getTime() : 0;
+				const blackWaitMs = black.waitingSince ? now - new Date(black.waitingSince).getTime() : 0;
+				waitSamples.push(whiteWaitMs, blackWaitMs);
+
+				applyPairing(white, black, now);
+				gameCounter += 1;
+				const gameId = `${name}-G${String(gameCounter).padStart(3, '0')}`;
+				const duration = gameDurationMs({ white, black, startMs: now, seed, gameNumber: gameCounter });
+				const resultColor = scoreResult(white, black, seed, gameCounter);
+				const game = {
+					id: gameId,
+					status: 'active',
+					whiteId: white._id,
+					blackId: black._id,
+					whiteStartRating: white.liveRating,
+					blackStartRating: black.liveRating,
+					startTime: now,
+					finishTime: now + duration,
+					resultColor,
+				};
+				activeGames.set(gameId, game);
+				scheduleEvent({ type: 'finish', time: game.finishTime, gameId });
+				metrics.gamesStarted += 1;
+
+				pairLog.push({
+					gameId,
+					whiteId: white._id,
+					blackId: black._id,
+					durationMinutes: minutes(duration),
+					resultColor,
+					priorMeetings: validation.priorMeetings,
+					violations: validation.violations,
+				});
+			}
+
+			waitingQueue = result.leftovers.map((player) => player._id);
+			const cycle = {
+				time: formatClock(startMs, now),
+				label,
+				queueSize: candidates.length,
+				pairingsCreated: result.pairings.length,
+				leftovers: result.leftovers.map((player) => player._id),
+				legalEdgeCount: result.legalEdgeCount,
+				totalPairingScore: Number((result.totalPairingScore ?? 0).toFixed(3)),
+				exhaustedNoLegalPairPool: result.exhaustedNoLegalPairPool,
+				usedFallback: result.usedFallback,
+				pairings: pairLog,
+			};
+			cycles.push(cycle);
+
+			if (result.exhaustedNoLegalPairPool) metrics.stalledPoolEvents += 1;
+			if (result.usedFallback) metrics.usedFallbackCycles += 1;
+			log('pair', `${cycle.pairingsCreated} games from ${cycle.queueSize} waiting players`, {
+				leftovers: cycle.leftovers,
+				usedFallback: result.usedFallback,
+			});
+		}
+
+		refreshStandings(players);
+		runPairingCycle('initial');
+
+		while (events.length) {
+			const nextTime = events[0].time;
+			if (nextTime > startMs + durationMs) break;
+			now = nextTime;
+
+			const simultaneous = [];
+			while (events.length && events[0].time === nextTime) simultaneous.push(events.shift());
+
+			for (const event of simultaneous.filter((item) => item.type === 'finish')) {
+				finishGame(event.gameId);
+			}
+			for (const event of simultaneous.filter((item) => item.type === 'leave')) {
+				pausePlayer(event.playerId, event.reason);
+			}
+
+			runPairingCycle(`after ${simultaneous.map((event) => event.type).join('+')}`);
+		}
+
+		refreshStandings(players);
+		const avgWaitMinutes = waitSamples.length
+			? waitSamples.reduce((sum, value) => sum + value, 0) / waitSamples.length / 60000
+			: 0;
+
+		return {
+			name,
+			metrics: {
+				...metrics,
+				avgWaitMinutes: Number(avgWaitMinutes.toFixed(2)),
+				playersStillWaiting: waitingQueue.length,
+				activeGamesAtEnd: activeGames.size,
+			},
+			cycles,
+			timeline,
+			finalStandings: refreshStandings(players).map(summarizePlayer),
+		};
+	} finally {
+		Date.now = originalDateNow;
+	}
+}
+
+function escapeHtml(value) {
+	return String(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;');
+}
+
+function bar(width, value, max) {
+	const actual = max > 0 ? Math.max(2, Math.round((value / max) * width)) : 0;
+	return `<svg viewBox="0 0 ${width} 12" width="${width}" height="12" role="img"><rect x="0" y="1" width="${actual}" height="10" rx="2"></rect></svg>`;
+}
+
+function renderHtml(report) {
+	const rows = report.results.map((result) => {
+		const m = result.metrics;
+		return `<tr>
+			<td>${escapeHtml(result.name)}</td>
+			<td>${m.gamesStarted}</td>
+			<td>${m.gamesCompleted}</td>
+			<td>${m.gamesCancelled}</td>
+			<td>${m.stalledPoolEvents}</td>
+			<td>${m.ruleViolations}</td>
+			<td>${m.engineWarnings}</td>
+			<td>${m.avgWaitMinutes}</td>
+		</tr>`;
+	}).join('');
+
+	const maxStarted = Math.max(...report.results.map((result) => result.metrics.gamesStarted), 1);
+	const bars = report.results.map((result) => `<div class="bar-row">
+		<strong>${escapeHtml(result.name)}</strong>
+		${bar(320, result.metrics.gamesStarted, maxStarted)}
+		<span>${result.metrics.gamesStarted} games started</span>
+	</div>`).join('');
+
+	const cycleTables = report.results.map((result) => {
+		const cycleRows = result.cycles.map((cycle) => `<tr>
+			<td>${cycle.time}</td>
+			<td>${cycle.queueSize}</td>
+			<td>${cycle.legalEdgeCount ?? ''}</td>
+			<td>${cycle.pairingsCreated}</td>
+			<td>${escapeHtml(cycle.leftovers.join(', '))}</td>
+			<td>${cycle.exhaustedNoLegalPairPool ? 'yes' : 'no'}</td>
+			<td>${cycle.usedFallback ? 'yes' : 'no'}</td>
+		</tr>`).join('');
+		return `<section>
+			<h2>${escapeHtml(result.name)} cycles</h2>
+			<table>
+				<thead><tr><th>Time</th><th>Waiting</th><th>Legal edges</th><th>Games</th><th>Leftovers</th><th>Stalled</th><th>Fallback</th></tr></thead>
+				<tbody>${cycleRows}</tbody>
+			</table>
+		</section>`;
+	}).join('');
+
+	const standings = report.results.map((result) => {
+		const rows = result.finalStandings.map((player, index) => `<tr>
+			<td>${index + 1}</td>
+			<td>${escapeHtml(player.id)}</td>
+			<td>${escapeHtml(player.name)}</td>
+			<td>${player.status}</td>
+			<td>${player.score}</td>
+			<td>${player.liveRating}</td>
+			<td>${player.gamesPlayed}</td>
+			<td>${escapeHtml(player.colors)}</td>
+		</tr>`).join('');
+		return `<section>
+			<h2>${escapeHtml(result.name)} final standings</h2>
+			<table>
+				<thead><tr><th>#</th><th>ID</th><th>Name</th><th>Status</th><th>Score</th><th>Live rating</th><th>Games</th><th>Colors</th></tr></thead>
+				<tbody>${rows}</tbody>
+			</table>
+		</section>`;
+	}).join('');
+
+	const eventRows = report.results.map((result) => {
+		const rows = result.timeline.slice(0, 160).map((event) => `<tr>
+			<td>${event.time}</td>
+			<td>${escapeHtml(result.name)}</td>
+			<td>${escapeHtml(event.type)}</td>
+			<td>${escapeHtml(event.message)}</td>
+		</tr>`).join('');
+		return rows;
+	}).join('');
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Pairing Algorithm Comparison</title>
+	<style>
+		body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211b; background: #f5f7f3; }
+		main { max-width: 1180px; margin: 0 auto; padding: 32px 20px 56px; }
+		h1 { margin: 0 0 8px; font-size: 30px; }
+		h2 { margin: 32px 0 12px; font-size: 20px; }
+		p { margin: 0 0 20px; color: #526055; }
+		table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #dfe5dc; }
+		th, td { padding: 8px 10px; border-bottom: 1px solid #e8ede5; text-align: left; font-size: 13px; vertical-align: top; }
+		th { background: #eef3ea; color: #334138; font-weight: 700; }
+		.bar-row { display: grid; grid-template-columns: 110px 330px 1fr; gap: 12px; align-items: center; margin: 10px 0; }
+		svg rect { fill: #49725b; }
+		.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; }
+		.panel { background: #fff; border: 1px solid #dfe5dc; padding: 16px; }
+		code { background: #e9eee6; padding: 2px 5px; }
+	</style>
+</head>
+<body>
+	<main>
+		<h1>Pairing Algorithm Comparison</h1>
+		<p>Scenario: ${report.scenario.players} players, ${report.scenario.durationMinutes} minutes, fixed leave schedule, asynchronous game finishes, seed <code>${report.scenario.seed}</code>.</p>
+		<section class="grid">
+			<div class="panel">
+				<h2>Summary</h2>
+				<table>
+					<thead><tr><th>Algorithm</th><th>Started</th><th>Completed</th><th>Cancelled</th><th>Stalled</th><th>Rule violations</th><th>Warnings</th><th>Avg wait</th></tr></thead>
+					<tbody>${rows}</tbody>
+				</table>
+			</div>
+			<div class="panel">
+				<h2>Games Started</h2>
+				${bars}
+			</div>
+		</section>
+		${cycleTables}
+		${standings}
+		<section>
+			<h2>Timeline Sample</h2>
+			<table>
+				<thead><tr><th>Time</th><th>Algorithm</th><th>Event</th><th>Detail</th></tr></thead>
+				<tbody>${eventRows}</tbody>
+			</table>
+		</section>
+	</main>
+</body>
+</html>`;
+}
+
+function runComparison(options) {
+	const startMs = Date.UTC(2026, 4, 19, 17, 30, 0);
+	const durationMs = options.durationMinutes * 60000;
+	const basePlayers = createPlayers(options.players, options.seed, startMs);
+	const leaveSchedule = buildLeaveSchedule(basePlayers, startMs, durationMs);
+	const scenario = {
+		players: options.players,
+		seed: options.seed,
+		durationMinutes: options.durationMinutes,
+		rules: {
+			maxColorStreak: MAX_COLOR_STREAK,
+			maxColorImbalance: MAX_COLOR_IMBALANCE,
+			maxMeetings: 2,
+		},
+		leaveSchedule: leaveSchedule.map((event) => ({
+			time: formatClock(startMs, event.time),
+			playerId: event.playerId,
+			reason: event.reason,
+		})),
+	};
+
+	const results = [
+		simulateAlgorithm({
+			name: 'greedy-current',
+			selector: selectGreedyBatchPairings,
+			basePlayers,
+			leaveSchedule,
+			seed: options.seed,
+			startMs,
+			durationMs,
+		}),
+		simulateAlgorithm({
+			name: 'graph-matching',
+			selector: selectGraphBatchPairings,
+			basePlayers,
+			leaveSchedule,
+			seed: options.seed,
+			startMs,
+			durationMs,
+		}),
+	];
+
+	return { scenario, results };
+}
+
+function writeOutputs(report, outputDir) {
+	fs.mkdirSync(outputDir, { recursive: true });
+	const jsonPath = path.join(outputDir, 'pairing-comparison-20p.json');
+	const htmlPath = path.join(outputDir, 'pairing-comparison-20p.html');
+	fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+	fs.writeFileSync(htmlPath, renderHtml(report));
+	return { jsonPath, htmlPath };
+}
+
+try {
+	const options = parseArgs(process.argv.slice(2));
+	const report = runComparison(options);
+	const outputs = writeOutputs(report, options.outputDir);
+
+	console.log('Pairing comparison simulation');
+	console.log(`players=${options.players} durationMinutes=${options.durationMinutes} seed=${options.seed}`);
+	for (const result of report.results) {
+		console.log(
+			`${result.name}: started=${result.metrics.gamesStarted} completed=${result.metrics.gamesCompleted} `
+			+ `cancelled=${result.metrics.gamesCancelled} stalled=${result.metrics.stalledPoolEvents} `
+			+ `violations=${result.metrics.ruleViolations} warnings=${result.metrics.engineWarnings} `
+			+ `avgWaitMinutes=${result.metrics.avgWaitMinutes}`
+		);
+	}
+	console.log(`json=${outputs.jsonPath}`);
+	console.log(`html=${outputs.htmlPath}`);
+	process.exit(report.results.every((result) => result.metrics.ruleViolations === 0 && result.metrics.engineWarnings === 0) ? 0 : 1);
+} catch (error) {
+	console.error(error.stack || error.message);
+	process.exit(1);
+}

--- a/backend/test-scripts/simulatePairingPareto.js
+++ b/backend/test-scripts/simulatePairingPareto.js
@@ -1,0 +1,620 @@
+const fs = require('fs');
+const path = require('path');
+
+const { runComparison } = require('./simulatePairingComparison');
+
+const DEFAULTS = {
+	players: [12, 20, 32, 48, 80],
+	settleSeconds: [0, 10, 20, 30, 45, 60, 90],
+	seedStart: 20260519,
+	seedCount: 8,
+	durationMinutes: 60,
+	outputDir: path.join(__dirname, '..', 'test-output'),
+};
+
+const PALETTE = [
+	'#326273',
+	'#4f7f52',
+	'#b66d12',
+	'#8c4f2d',
+	'#5f5aa2',
+	'#ab3e5b',
+	'#2f7f7f',
+	'#79613f',
+];
+
+const SCREENING_RULES = {
+	throughputLossRatio: 0.15,
+	longWaitsOver5PerRun: 0.5,
+	longWaitsOver8PerRun: 0,
+	avgWaitMinutes: 2.5,
+	thinPoolMinimum: 4,
+	thinPoolPlayerRatio: 0.08,
+	thinPoolMaximum: 6,
+};
+
+function parseNumberList(value, flagName) {
+	const parsed = String(value)
+		.split(',')
+		.map((part) => Number(part.trim()))
+		.filter((value) => Number.isFinite(value));
+
+	if (!parsed.length) throw new Error(`Invalid --${flagName}: ${value}`);
+	return parsed;
+}
+
+function parseArgs(argv) {
+	const opts = { ...DEFAULTS };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (!arg.startsWith('--')) continue;
+
+		const key = arg.slice(2);
+		const next = argv[i + 1];
+		if (key === 'players') {
+			opts.players = parseNumberList(next, key);
+			i += 1;
+		} else if (key === 'settleSeconds') {
+			opts.settleSeconds = parseNumberList(next, key);
+			i += 1;
+		} else if (['seedStart', 'seedCount', 'durationMinutes'].includes(key)) {
+			const value = Number(next);
+			if (!Number.isFinite(value)) throw new Error(`Invalid numeric value for --${key}: ${next}`);
+			opts[key] = value;
+			i += 1;
+		} else if (key === 'outputDir') {
+			opts.outputDir = next;
+			i += 1;
+		}
+	}
+
+	opts.players = [...new Set(opts.players)].sort((a, b) => a - b);
+	opts.settleSeconds = [...new Set(opts.settleSeconds)].sort((a, b) => a - b);
+	opts.seedCount = Math.max(1, Math.round(opts.seedCount));
+	return opts;
+}
+
+function round(value, digits = 2) {
+	return Number(value.toFixed(digits));
+}
+
+function escapeHtml(value) {
+	return String(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;');
+}
+
+function csvValue(value) {
+	if (value === null || value === undefined) return '';
+	const text = String(value);
+	return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function sumPairingScore(cycles) {
+	return cycles.reduce((sum, cycle) => sum + (Number(cycle.totalPairingScore) || 0), 0);
+}
+
+function runSweep(options) {
+	const seeds = Array.from({ length: options.seedCount }, (_, index) => options.seedStart + index);
+	const rawRows = [];
+	const groups = new Map();
+
+	for (const playerCount of options.players) {
+		for (const settleSeconds of options.settleSeconds) {
+			for (const seed of seeds) {
+				const report = runComparison({
+					players: playerCount,
+					durationMinutes: options.durationMinutes,
+					settleSeconds,
+					seed,
+				});
+
+				for (const result of report.results) {
+					const m = result.metrics;
+					const totalPairingScore = sumPairingScore(result.cycles);
+					const row = {
+						players: playerCount,
+						settleSeconds,
+						seed,
+						algorithm: result.name,
+						gamesStarted: m.gamesStarted,
+						gamesCompleted: m.gamesCompleted,
+						gamesCancelled: m.gamesCancelled,
+						stalledPoolEvents: m.stalledPoolEvents,
+						ruleViolations: m.ruleViolations,
+						engineWarnings: m.engineWarnings,
+						avgWaitMinutes: m.avgWaitMinutes,
+						maxWaitMinutes: m.maxWaitMinutes,
+						waitsOver5Minutes: m.waitsOver5Minutes,
+						waitsOver8Minutes: m.waitsOver8Minutes,
+						avgPairingPoolSize: m.avgPairingPoolSize,
+						maxPairingPoolSize: m.maxPairingPoolSize,
+						cyclesWithPoolAtLeast6: m.cyclesWithPoolAtLeast6,
+						cyclesWithPoolAtLeast10: m.cyclesWithPoolAtLeast10,
+						avgPairingScore: m.gamesStarted ? totalPairingScore / m.gamesStarted : 0,
+					};
+					rawRows.push(row);
+
+					const key = `${playerCount}|${settleSeconds}|${result.name}`;
+					if (!groups.has(key)) {
+						groups.set(key, {
+							players: playerCount,
+							settleSeconds,
+							algorithm: result.name,
+							runs: 0,
+							gamesStarted: 0,
+							gamesCompleted: 0,
+							gamesCancelled: 0,
+							stalledPoolEvents: 0,
+							ruleViolations: 0,
+							engineWarnings: 0,
+							avgWaitMinutes: 0,
+							maxWaitMinutes: 0,
+							waitsOver5Minutes: 0,
+							waitsOver8Minutes: 0,
+							avgPairingPoolSize: 0,
+							maxPairingPoolSize: 0,
+							cyclesWithPoolAtLeast6: 0,
+							cyclesWithPoolAtLeast10: 0,
+							avgPairingScore: 0,
+							worstMaxWaitMinutes: 0,
+						});
+					}
+
+					const group = groups.get(key);
+					group.runs += 1;
+					group.gamesStarted += row.gamesStarted;
+					group.gamesCompleted += row.gamesCompleted;
+					group.gamesCancelled += row.gamesCancelled;
+					group.stalledPoolEvents += row.stalledPoolEvents;
+					group.ruleViolations += row.ruleViolations;
+					group.engineWarnings += row.engineWarnings;
+					group.avgWaitMinutes += row.avgWaitMinutes;
+					group.maxWaitMinutes += row.maxWaitMinutes;
+					group.waitsOver5Minutes += row.waitsOver5Minutes;
+					group.waitsOver8Minutes += row.waitsOver8Minutes;
+					group.avgPairingPoolSize += row.avgPairingPoolSize;
+					group.maxPairingPoolSize = Math.max(group.maxPairingPoolSize, row.maxPairingPoolSize);
+					group.cyclesWithPoolAtLeast6 += row.cyclesWithPoolAtLeast6;
+					group.cyclesWithPoolAtLeast10 += row.cyclesWithPoolAtLeast10;
+					group.avgPairingScore += row.avgPairingScore;
+					group.worstMaxWaitMinutes = Math.max(group.worstMaxWaitMinutes, row.maxWaitMinutes);
+				}
+			}
+		}
+	}
+
+	const aggregates = [...groups.values()].map((group) => ({
+		players: group.players,
+		settleSeconds: group.settleSeconds,
+		algorithm: group.algorithm,
+		runs: group.runs,
+		avgGamesStarted: round(group.gamesStarted / group.runs),
+		avgGamesCompleted: round(group.gamesCompleted / group.runs),
+		avgGamesCancelled: round(group.gamesCancelled / group.runs),
+		avgStalledPoolEvents: round(group.stalledPoolEvents / group.runs),
+		totalRuleViolations: group.ruleViolations,
+		totalEngineWarnings: group.engineWarnings,
+		avgWaitMinutes: round(group.avgWaitMinutes / group.runs),
+		avgMaxWaitMinutes: round(group.maxWaitMinutes / group.runs),
+		worstMaxWaitMinutes: round(group.worstMaxWaitMinutes),
+		waitsOver5PerRun: round(group.waitsOver5Minutes / group.runs),
+		waitsOver8PerRun: round(group.waitsOver8Minutes / group.runs),
+		avgPairingPoolSize: round(group.avgPairingPoolSize / group.runs),
+		maxPairingPoolSize: group.maxPairingPoolSize,
+		avgCyclesWithPoolAtLeast6: round(group.cyclesWithPoolAtLeast6 / group.runs),
+		avgCyclesWithPoolAtLeast10: round(group.cyclesWithPoolAtLeast10 / group.runs),
+		avgPairingScore: round(group.avgPairingScore / group.runs, 3),
+		isValid: group.ruleViolations === 0 && group.engineWarnings === 0,
+		isPareto: false,
+		isPareto2d: false,
+		isProblematic: false,
+		throughputRatio: 1,
+		screeningReasons: [],
+	}));
+
+	markParetoFrontiers(aggregates);
+	markProblematicConfigurations(aggregates);
+	const screenedOut = aggregates.filter((item) => item.isProblematic);
+
+	return {
+		scenario: {
+			players: options.players,
+			settleSeconds: options.settleSeconds,
+			seeds,
+			seedStart: options.seedStart,
+			seedCount: options.seedCount,
+			durationMinutes: options.durationMinutes,
+			timeControl: '3+2 blitz',
+			paretoObjectives: [
+				'maximize avg games started',
+				'maximize average pairing pool size',
+				'minimize average wait',
+				'minimize waits over 5 minutes',
+			],
+			screeningRules: {
+				tooFewGames: `avg games started is more than ${Math.round(SCREENING_RULES.throughputLossRatio * 100)}% below the best value for the same player count and algorithm`,
+				longWaits: `waits over 8 minutes occur, waits over 5 minutes average at least ${SCREENING_RULES.longWaitsOver5PerRun} per run, or average wait is at least ${SCREENING_RULES.avgWaitMinutes} minutes`,
+				thinQueue: `average pool size is below max(${SCREENING_RULES.thinPoolMinimum}, min(${SCREENING_RULES.thinPoolMaximum}, players * ${SCREENING_RULES.thinPoolPlayerRatio}))`,
+			},
+		},
+		screenedOut,
+		aggregates,
+		rawRows,
+	};
+}
+
+function dominates(a, b) {
+	return a.isValid
+		&& a.avgGamesStarted >= b.avgGamesStarted
+		&& a.avgPairingPoolSize >= b.avgPairingPoolSize
+		&& a.avgWaitMinutes <= b.avgWaitMinutes
+		&& a.waitsOver5PerRun <= b.waitsOver5PerRun
+		&& (
+			a.avgGamesStarted > b.avgGamesStarted
+			|| a.avgPairingPoolSize > b.avgPairingPoolSize
+			|| a.avgWaitMinutes < b.avgWaitMinutes
+			|| a.waitsOver5PerRun < b.waitsOver5PerRun
+		);
+}
+
+function dominates2d(a, b) {
+	return a.isValid
+		&& a.avgGamesStarted >= b.avgGamesStarted
+		&& a.avgWaitMinutes <= b.avgWaitMinutes
+		&& (a.avgGamesStarted > b.avgGamesStarted || a.avgWaitMinutes < b.avgWaitMinutes);
+}
+
+function markParetoFrontiers(aggregates) {
+	const groups = new Map();
+	for (const item of aggregates) {
+		const key = `${item.players}|${item.algorithm}`;
+		if (!groups.has(key)) groups.set(key, []);
+		groups.get(key).push(item);
+	}
+
+	for (const points of groups.values()) {
+		for (const point of points) {
+			point.isPareto = point.isValid && !points.some((candidate) => candidate !== point && dominates(candidate, point));
+			point.isPareto2d = point.isValid && !points.some((candidate) => candidate !== point && dominates2d(candidate, point));
+		}
+	}
+}
+
+function thinPoolThreshold(players) {
+	return Math.max(
+		SCREENING_RULES.thinPoolMinimum,
+		Math.min(SCREENING_RULES.thinPoolMaximum, players * SCREENING_RULES.thinPoolPlayerRatio),
+	);
+}
+
+function markProblematicConfigurations(aggregates) {
+	const groups = new Map();
+	for (const item of aggregates) {
+		const key = `${item.players}|${item.algorithm}`;
+		if (!groups.has(key)) groups.set(key, []);
+		groups.get(key).push(item);
+	}
+
+	for (const points of groups.values()) {
+		const maxStarted = Math.max(...points.map((point) => point.avgGamesStarted));
+		for (const point of points) {
+			const reasons = [];
+			const poolFloor = thinPoolThreshold(point.players);
+			point.throughputRatio = maxStarted > 0 ? round(point.avgGamesStarted / maxStarted, 3) : 0;
+			point.thinPoolThreshold = round(poolFloor, 2);
+
+			if (!point.isValid) {
+				reasons.push('rules/warnings');
+			}
+			if (point.throughputRatio < 1 - SCREENING_RULES.throughputLossRatio) {
+				reasons.push(`too few games (${Math.round(point.throughputRatio * 100)}% of best)`);
+			}
+			if (
+				point.waitsOver8PerRun > SCREENING_RULES.longWaitsOver8PerRun
+				|| point.waitsOver5PerRun >= SCREENING_RULES.longWaitsOver5PerRun
+				|| point.avgWaitMinutes >= SCREENING_RULES.avgWaitMinutes
+			) {
+				reasons.push('long waits');
+			}
+			if (point.avgPairingPoolSize < poolFloor) {
+				reasons.push(`thin queue (<${round(poolFloor, 1)} avg pool)`);
+			}
+
+			point.screeningReasons = reasons;
+			point.isProblematic = reasons.length > 0;
+		}
+	}
+}
+
+function renderPlot(points, playerCount) {
+	const graphPoints = points
+		.filter((point) => point.players === playerCount && point.algorithm === 'graph-matching')
+		.sort((left, right) => left.settleSeconds - right.settleSeconds);
+	const width = 760;
+	const height = 360;
+	const pad = { left: 62, right: 28, top: 28, bottom: 54 };
+	const plotWidth = width - pad.left - pad.right;
+	const plotHeight = height - pad.top - pad.bottom;
+	const xMax = Math.max(...graphPoints.map((point) => point.avgWaitMinutes), 1) * 1.12;
+	const yMinRaw = Math.min(...graphPoints.map((point) => point.avgGamesStarted));
+	const yMaxRaw = Math.max(...graphPoints.map((point) => point.avgGamesStarted));
+	const yMin = Math.max(0, yMinRaw - Math.max(2, (yMaxRaw - yMinRaw) * 0.18));
+	const yMax = yMaxRaw + Math.max(2, (yMaxRaw - yMinRaw) * 0.18);
+	const poolMin = Math.min(...graphPoints.map((point) => point.avgPairingPoolSize));
+	const poolMax = Math.max(...graphPoints.map((point) => point.avgPairingPoolSize));
+	const colorBySettle = new Map(graphPoints.map((point, index) => [point.settleSeconds, PALETTE[index % PALETTE.length]]));
+
+	const x = (value) => pad.left + (value / xMax) * plotWidth;
+	const y = (value) => pad.top + (1 - ((value - yMin) / (yMax - yMin))) * plotHeight;
+	const r = (point) => {
+		if (poolMax === poolMin) return 7;
+		return 5 + ((point.avgPairingPoolSize - poolMin) / (poolMax - poolMin)) * 8;
+	};
+
+	const yTicks = Array.from({ length: 5 }, (_, index) => yMin + ((yMax - yMin) * index) / 4);
+	const xTicks = Array.from({ length: 5 }, (_, index) => (xMax * index) / 4);
+	const frontier = graphPoints.filter((point) => point.isPareto2d).sort((left, right) => left.avgWaitMinutes - right.avgWaitMinutes);
+	const frontierPath = frontier.map((point) => `${x(point.avgWaitMinutes)},${y(point.avgGamesStarted)}`).join(' ');
+
+	const grid = [
+		...yTicks.map((tick) => `<line x1="${pad.left}" y1="${y(tick)}" x2="${width - pad.right}" y2="${y(tick)}" class="grid-line"></line><text x="${pad.left - 10}" y="${y(tick) + 4}" text-anchor="end">${round(tick, 1)}</text>`),
+		...xTicks.map((tick) => `<line x1="${x(tick)}" y1="${pad.top}" x2="${x(tick)}" y2="${height - pad.bottom}" class="grid-line"></line><text x="${x(tick)}" y="${height - pad.bottom + 24}" text-anchor="middle">${round(tick, 1)}</text>`),
+	].join('');
+
+	const markers = graphPoints.map((point) => {
+		const px = x(point.avgWaitMinutes);
+		const py = y(point.avgGamesStarted);
+		const classes = [
+			point.isPareto ? 'pareto' : '',
+			point.isProblematic ? 'problematic' : '',
+		].filter(Boolean).join(' ');
+		return `<g class="${classes}">
+			<circle cx="${px}" cy="${py}" r="${round(r(point), 1)}" fill="${colorBySettle.get(point.settleSeconds)}"></circle>
+			<text x="${px}" y="${py - 12}" text-anchor="middle">${point.settleSeconds}s</text>
+			<title>${point.settleSeconds}s: ${point.avgGamesStarted} games, ${point.avgWaitMinutes}m avg wait, avg pool ${point.avgPairingPoolSize}${point.isProblematic ? `, flagged: ${point.screeningReasons.join('; ')}` : ''}</title>
+		</g>`;
+	}).join('');
+
+	const legend = graphPoints.map((point, index) => {
+		const xPos = pad.left + index * 86;
+		const yPos = height - 14;
+		return `<g><circle cx="${xPos}" cy="${yPos}" r="5" fill="${colorBySettle.get(point.settleSeconds)}"></circle><text x="${xPos + 10}" y="${yPos + 4}">${point.settleSeconds}s</text></g>`;
+	}).join('');
+
+	return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Pareto plot for ${playerCount} players">
+		<rect x="0" y="0" width="${width}" height="${height}" class="plot-bg"></rect>
+		${grid}
+		<line x1="${pad.left}" y1="${height - pad.bottom}" x2="${width - pad.right}" y2="${height - pad.bottom}" class="axis"></line>
+		<line x1="${pad.left}" y1="${pad.top}" x2="${pad.left}" y2="${height - pad.bottom}" class="axis"></line>
+		${frontierPath ? `<polyline points="${frontierPath}" class="frontier-line"></polyline>` : ''}
+		${markers}
+		<text x="${width / 2}" y="${height - 24}" text-anchor="middle" class="axis-label">Average wait before pairing, minutes (lower is better)</text>
+		<text transform="translate(18 ${height / 2}) rotate(-90)" text-anchor="middle" class="axis-label">Games started per hour (higher is better)</text>
+		<text x="${pad.left}" y="18" class="chart-title">${playerCount} players, graph matching</text>
+		<text x="${width - pad.right}" y="18" text-anchor="end" class="chart-note">Circle size = average pool size</text>
+		${legend}
+	</svg>`;
+}
+
+function renderHtml(report) {
+	const screenedRows = report.screenedOut
+		.filter((item) => item.algorithm === 'graph-matching')
+		.sort((left, right) => left.players - right.players || left.settleSeconds - right.settleSeconds)
+		.map((item) => `<tr>
+		<td>${item.players}</td>
+		<td>${item.settleSeconds}s</td>
+		<td>${item.avgGamesStarted}</td>
+		<td>${Math.round(item.throughputRatio * 100)}%</td>
+		<td>${item.avgWaitMinutes}</td>
+		<td>${item.waitsOver5PerRun}</td>
+		<td>${item.avgPairingPoolSize}</td>
+		<td>${escapeHtml(item.screeningReasons.join(', '))}</td>
+	</tr>`).join('');
+
+	const screeningRuleRows = Object.entries(report.scenario.screeningRules).map(([name, description]) => `<tr>
+		<td>${escapeHtml(name)}</td>
+		<td>${escapeHtml(description)}</td>
+	</tr>`).join('');
+
+	const frontierRows = report.aggregates
+		.filter((item) => item.algorithm === 'graph-matching' && item.isPareto && !item.isProblematic)
+		.sort((left, right) => left.players - right.players || left.settleSeconds - right.settleSeconds)
+		.map((item) => `<tr>
+		<td>${item.players}</td>
+		<td>${item.settleSeconds}s</td>
+		<td>${item.avgGamesStarted}</td>
+		<td>${Math.round(item.throughputRatio * 100)}%</td>
+		<td>${item.avgWaitMinutes}</td>
+		<td>${item.waitsOver5PerRun}</td>
+		<td>${item.avgPairingPoolSize}</td>
+		<td>${item.avgStalledPoolEvents}</td>
+	</tr>`).join('');
+
+	const chartSections = report.scenario.players.map((playerCount) => `<section class="panel chart-panel">
+		${renderPlot(report.aggregates, playerCount)}
+	</section>`).join('');
+
+	const aggregateRows = report.aggregates
+		.sort((left, right) => (
+			left.players - right.players
+			|| left.algorithm.localeCompare(right.algorithm)
+			|| left.settleSeconds - right.settleSeconds
+		))
+		.map((item) => `<tr class="${item.isProblematic ? 'problematic-row' : ''}">
+			<td>${item.players}</td>
+			<td>${escapeHtml(item.algorithm)}</td>
+			<td>${item.settleSeconds}s</td>
+			<td>${item.avgGamesStarted}</td>
+			<td>${item.avgGamesCompleted}</td>
+			<td>${Math.round(item.throughputRatio * 100)}%</td>
+			<td>${item.avgWaitMinutes}</td>
+			<td>${item.avgMaxWaitMinutes}</td>
+			<td>${item.waitsOver5PerRun}</td>
+			<td>${item.avgPairingPoolSize}</td>
+			<td>${item.avgStalledPoolEvents}</td>
+			<td>${item.avgPairingScore}</td>
+			<td>${item.isPareto ? 'yes' : 'no'}</td>
+			<td>${item.isProblematic ? 'yes' : ''}</td>
+			<td>${escapeHtml(item.screeningReasons.join(', '))}</td>
+			<td>${item.totalRuleViolations}</td>
+			<td>${item.totalEngineWarnings}</td>
+		</tr>`).join('');
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Pairing Pareto Sweep</title>
+	<style>
+		body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17211b; background: #f3f5ee; }
+		main { max-width: 1240px; margin: 0 auto; padding: 32px 20px 56px; }
+		h1 { margin: 0 0 8px; font-size: 32px; }
+		h2 { margin: 32px 0 12px; font-size: 21px; }
+		p { color: #4f5d52; line-height: 1.45; }
+		table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #d9e0d2; }
+		th, td { padding: 8px 9px; border-bottom: 1px solid #e7ece2; text-align: left; font-size: 13px; }
+		th { background: #e9efdf; color: #2d3c2f; }
+		.panel { background: #fff; border: 1px solid #d9e0d2; padding: 16px; margin-bottom: 18px; box-shadow: 0 12px 26px rgba(53, 67, 42, 0.06); }
+		.chart-panel { overflow-x: auto; }
+		.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 18px; }
+		.problematic-row { background: #fff2ee; }
+		code { background: #e9eee2; padding: 2px 5px; }
+		svg { width: 100%; min-width: 720px; height: auto; }
+		svg text { font-size: 12px; fill: #334138; }
+		.plot-bg { fill: #fbfcf8; }
+		.grid-line { stroke: #dfe5d8; stroke-width: 1; }
+		.axis { stroke: #3b493e; stroke-width: 1.4; }
+		.axis-label, .chart-note { fill: #5a685d; }
+		.chart-title { font-weight: 700; font-size: 15px; }
+		.frontier-line { fill: none; stroke: #101811; stroke-width: 2.2; stroke-dasharray: 5 4; }
+		circle { opacity: 0.84; stroke: #fff; stroke-width: 1.2; }
+		.pareto circle { stroke: #101811; stroke-width: 2.2; opacity: 0.95; }
+		.problematic circle { stroke: #c92727; stroke-width: 3; opacity: 0.72; }
+	</style>
+</head>
+<body>
+	<main>
+		<h1>Pairing Settle Window Pareto Sweep</h1>
+		<p>Scenario: ${report.scenario.players.join(', ')} players, ${report.scenario.durationMinutes}-minute 3+2 arena, settle windows ${report.scenario.settleSeconds.join(', ')} seconds, ${report.scenario.seedCount} deterministic seeds starting at <code>${report.scenario.seedStart}</code>. The frontier is nondominated under the selected metrics; this report does not choose a winner. Red outlines/rows mark configurations screened as problematic because of long waits, low throughput, or a thin queue.</p>
+
+		<section class="panel">
+			<h2>Screening Rules</h2>
+			<table>
+				<thead><tr><th>Flag</th><th>Rule</th></tr></thead>
+				<tbody>${screeningRuleRows}</tbody>
+			</table>
+		</section>
+
+		<section class="panel">
+			<h2>Problematic Graph-Matching Configurations</h2>
+			<table>
+				<thead><tr><th>Players</th><th>Settle</th><th>Avg games</th><th>Throughput</th><th>Avg wait</th><th>&gt;5m/run</th><th>Avg pool</th><th>Reasons</th></tr></thead>
+				<tbody>${screenedRows}</tbody>
+			</table>
+		</section>
+
+		<section class="panel">
+			<h2>Non-Problematic Graph-Matching Pareto Points</h2>
+			<table>
+				<thead><tr><th>Players</th><th>Settle</th><th>Avg games</th><th>Throughput</th><th>Avg wait</th><th>&gt;5m/run</th><th>Avg pool</th><th>Stalls/run</th></tr></thead>
+				<tbody>${frontierRows}</tbody>
+			</table>
+		</section>
+
+		<h2>Pareto Plots</h2>
+		<div class="grid">${chartSections}</div>
+
+		<section class="panel">
+			<h2>Aggregate Data</h2>
+			<table>
+				<thead><tr><th>Players</th><th>Algorithm</th><th>Settle</th><th>Started</th><th>Completed</th><th>Throughput</th><th>Avg wait</th><th>Avg max wait</th><th>&gt;5m/run</th><th>Avg pool</th><th>Stalls</th><th>Pair score</th><th>Pareto</th><th>Problem</th><th>Reasons</th><th>Violations</th><th>Warnings</th></tr></thead>
+				<tbody>${aggregateRows}</tbody>
+			</table>
+		</section>
+	</main>
+</body>
+</html>`;
+}
+
+function writeOutputs(report, outputDir) {
+	fs.mkdirSync(outputDir, { recursive: true });
+	const playerPart = `${Math.min(...report.scenario.players)}-${Math.max(...report.scenario.players)}p`;
+	const prefix = `pairing-pareto-${playerPart}-${report.scenario.durationMinutes}m-${report.scenario.seedCount}seeds`;
+	const jsonPath = path.join(outputDir, `${prefix}.json`);
+	const csvPath = path.join(outputDir, `${prefix}.csv`);
+	const htmlPath = path.join(outputDir, `${prefix}.html`);
+
+	const csvColumns = [
+		'players',
+		'algorithm',
+		'settleSeconds',
+		'runs',
+		'avgGamesStarted',
+		'avgGamesCompleted',
+		'avgWaitMinutes',
+		'avgMaxWaitMinutes',
+		'worstMaxWaitMinutes',
+		'waitsOver5PerRun',
+		'waitsOver8PerRun',
+		'avgPairingPoolSize',
+		'maxPairingPoolSize',
+		'avgStalledPoolEvents',
+		'avgPairingScore',
+		'throughputRatio',
+		'isPareto',
+		'isProblematic',
+		'screeningReasons',
+		'totalRuleViolations',
+		'totalEngineWarnings',
+	];
+	const csvRows = [
+		csvColumns.join(','),
+		...report.aggregates.map((row) => csvColumns.map((column) => csvValue(row[column])).join(',')),
+	].join('\n');
+
+	fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+	fs.writeFileSync(csvPath, `${csvRows}\n`);
+	fs.writeFileSync(htmlPath, renderHtml(report));
+	return { jsonPath, csvPath, htmlPath };
+}
+
+function runCli() {
+	try {
+		const options = parseArgs(process.argv.slice(2));
+		const report = runSweep(options);
+		const outputs = writeOutputs(report, options.outputDir);
+
+		console.log('Pairing Pareto sweep');
+		console.log(`players=${options.players.join(',')} settleSeconds=${options.settleSeconds.join(',')} durationMinutes=${options.durationMinutes} seeds=${options.seedStart}..${options.seedStart + options.seedCount - 1}`);
+		for (const playerCount of options.players) {
+			const flagged = report.screenedOut
+				.filter((item) => item.players === playerCount && item.algorithm === 'graph-matching')
+				.sort((left, right) => left.settleSeconds - right.settleSeconds);
+			const details = flagged.length
+				? flagged.map((item) => `${item.settleSeconds}s(${item.screeningReasons.join('; ')})`).join(', ')
+				: 'none';
+			console.log(`players=${playerCount}: problematic graph configs=${details}`);
+		}
+		console.log(`json=${outputs.jsonPath}`);
+		console.log(`csv=${outputs.csvPath}`);
+		console.log(`html=${outputs.htmlPath}`);
+	} catch (error) {
+		console.error(error.stack || error.message);
+		process.exit(1);
+	}
+}
+
+if (require.main === module) {
+	runCli();
+}
+
+module.exports = {
+	DEFAULTS,
+	parseArgs,
+	runSweep,
+	writeOutputs,
+	renderHtml,
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       AUTH_ENABLED: ${AUTH_ENABLED}
       CORS_ORIGIN: ${CORS_ORIGIN}
       APP_MODE: ${APP_MODE}
+      PAIRING_SETTLE_MS: ${PAIRING_SETTLE_MS}
     depends_on:
       mongo:
         condition: service_healthy

--- a/docs/tournament-operations.md
+++ b/docs/tournament-operations.md
@@ -1,0 +1,251 @@
+# Tournament Operations Guide
+
+This guide is for running an OTB Arena tournament with NTUArena. The production pairing path today is Arena matchmaking; Swiss is listed in the product roadmap, but Arena is the implemented real-time worker path.
+
+## 1. Install And Start
+
+### Docker setup
+
+Prerequisites:
+
+- Docker
+- Docker Compose
+
+From the repository root:
+
+```bash
+cp .env.example .env
+# Edit .env before exposing the app to players/admins.
+docker compose up -d --build
+```
+
+Open the app through Nginx:
+
+```text
+http://localhost
+```
+
+Useful checks:
+
+```bash
+docker compose ps
+docker compose logs -f backend
+```
+
+If you only change environment variables, recreate the backend container:
+
+```bash
+docker compose up -d --force-recreate backend
+```
+
+If you change `APP_MODE`, rebuild because Docker Compose selects a different frontend Dockerfile and Nginx config:
+
+```bash
+docker compose up -d --build
+```
+
+### Local script/test setup
+
+Simulation and test scripts run from `backend/`:
+
+```bash
+cd backend
+npm ci
+npm test
+```
+
+## 2. Required Environment Decisions
+
+The most important toggles are in `.env`.
+
+| Variable | Local/dev value | Real tournament value | Notes |
+|---|---:|---:|---|
+| `APP_MODE` | `dev` | `prod` or `dev` | `dev` runs the React dev server. `prod` serves the built frontend through Nginx. |
+| `NODE_ENV` | `development` | `production` | Use `production` for public deployments. |
+| `AUTH_ENABLED` | `false` | `true` | `false` makes every request act as a mock admin. Useful locally, unsafe publicly. |
+| `CORS_ORIGIN` | `*` | your app origin | Example: `https://arena.example.com`. |
+| `JWT_SECRET` | dummy value | strong random secret | Generate with `openssl rand -base64 64`. |
+| `REDIS_PASSWORD` | dummy value | strong password | Must match `REDIS_URL`. |
+| `REDIS_URL` | compose default | password-protected Redis URL | Required for pairing queues. |
+| `MONGO_URI` | compose default | production Mongo URI | Mongo must support transactions; the compose setup uses a single-node replica set. |
+| `PAIRING_SETTLE_MS` | `30000` | tune per event | Main Arena pairing behavior toggle. See below. |
+
+## 3. Pairing Configuration
+
+### Current production algorithm
+
+Arena pairing uses a graph-based maximum-weight matching engine. The worker builds legal edges between waiting players, scores the edges, and solves the matching using Edmonds blossom matching. The old greedy selector still exists for simulations/tests but is not the production selector.
+
+Hard legality rules:
+
+- No immediate rematch.
+- No more than 2 recent meetings against the same opponent.
+- Rematches must swap colors when possible.
+- Color streak and total color imbalance constraints are enforced.
+
+Soft scoring preferences:
+
+- Similar score/performance.
+- Similar rank.
+- Similar rating.
+- Similar rating deviation, when available.
+- Similar berserk/zerk tendency, when available.
+- Fewer repeated meetings.
+- Relief for players waiting longer.
+- Better color balance.
+
+### Settle window
+
+`PAIRING_SETTLE_MS` is the quiet window before the worker pairs the waiting pool.
+
+Example with `PAIRING_SETTLE_MS=30000`:
+
+1. A game result is submitted.
+2. Finished players are re-enqueued after the result handling delay.
+3. The worker waits until 30 seconds have passed since the newest queued player.
+4. If another player enters the queue during that time, the quiet window moves forward.
+5. When the queue has been quiet for 30 seconds, graph matching runs on the available pool.
+
+The initial tournament pool is treated as already settled, so starting the tournament does not wait 30 seconds before first pairings.
+
+Tradeoff:
+
+| Settle value | Expected behavior |
+|---:|---|
+| `0` to `10000` | More games and short waits, but thinner pairing pools and more low-choice cycles. |
+| `20000` to `30000` | Balanced range for many 20-32 player OTB arenas. |
+| `45000` and above | Fuller pools and fewer stalled cycles, but lower throughput and more long waits. |
+
+Do not treat these as universal recommendations. Use the Pareto simulation for the expected player count and tournament conditions.
+
+### Other pairing runtime parameters
+
+These are code defaults, not environment toggles today:
+
+| Parameter | Current value | Meaning |
+|---|---:|---|
+| `batchSize` | `80` | Max queued player snapshots the worker considers in one cycle. |
+| `idleMs` | `400` | Sleep time when no pairing work is available. |
+| `REQUEUE_DELAY_MS` | `5000` | Delay after result submission before players return to the queue. |
+
+## 4. Running A Tournament
+
+A typical OTB Arena flow:
+
+1. Configure `.env` and start Docker Compose.
+2. Log in as an admin, or use `AUTH_ENABLED=false` only for local/private testing.
+3. Create the tournament as Arena format.
+4. Register players manually or import them by CSV.
+5. Confirm pairings settings, especially `PAIRING_SETTLE_MS`.
+6. Start the tournament from the admin UI. This seeds the Redis pairing queue and starts a tournament worker.
+7. Pairings are created automatically as players become available.
+8. Enter game results as games finish. Players can finish asynchronously; they do not need to finish in rounds.
+9. Pause/withdraw players who leave early so they are removed from the pairing queue and any active game is handled.
+10. Monitor standings, live games, and backend logs for pairing warnings.
+11. Stop/complete the tournament from the admin UI when the event is over.
+
+Operational notes:
+
+- Redis must be healthy before pairing can work.
+- MongoDB transactions require the replica-set setup; use the provided compose config unless you know your external Mongo supports transactions.
+- If the backend logs `no legal pairings available in current pool`, the worker requeues leftovers and waits for future players/results.
+- For a public deployment, do not leave `AUTH_ENABLED=false`, `CORS_ORIGIN=*`, or dummy secrets.
+
+## 5. Testing And Validation
+
+Run backend checks from `backend/`:
+
+```bash
+cd backend
+npm ci
+
+# Full backend test suite
+CORS_ORIGIN=http://localhost APP_MODE=test NODE_ENV=test npm test -- --runInBand
+
+# Pairing-focused regression tests
+npm test -- --runInBand pairingWorker.test.js
+
+# Syntax-check simulation tools
+node --check test-scripts/simulateArenaPairings.js
+node --check test-scripts/simulatePairingComparison.js
+node --check test-scripts/simulatePairingPareto.js
+```
+
+Run frontend checks from `view/`:
+
+```bash
+cd view
+npm ci
+npm test -- --watchAll=false
+npm run build
+```
+
+Validate a Docker deployment from the repository root:
+
+```bash
+docker compose up -d --build
+docker compose ps
+docker compose logs -f backend
+```
+
+Before merging pairing changes, run at least:
+
+```bash
+cd backend
+CORS_ORIGIN=http://localhost APP_MODE=test NODE_ENV=test npm test -- --runInBand
+npm run simulate:pairing-comparison -- --players 20 --durationMinutes 60 --settleSeconds 30 --seed 20260519
+npm run simulate:pairing-pareto -- --players 12,20 --settleSeconds 10,30 --seedCount 2 --durationMinutes 20
+```
+
+## 6. Simulation And Tuning Tools
+
+Run these from `backend/` after `npm ci`.
+
+### Single arena pairing simulation
+
+```bash
+npm run simulate:arena-pairings -- --players 20 --rounds 10 --seed 20260419
+```
+
+This validates pairing legality over repeated rounds and logs pairings/rule checks.
+
+### One-hour realistic comparison
+
+```bash
+npm run simulate:pairing-comparison -- --players 20 --durationMinutes 60 --settleSeconds 30 --seed 20260519
+```
+
+Outputs JSON and HTML under `backend/test-output/`. It simulates asynchronous 3+2 game finishes, variance in game duration, and players leaving early.
+
+### Pareto settle-window sweep
+
+```bash
+npm run simulate:pairing-pareto
+```
+
+Default sweep:
+
+- Player counts: `12,20,32,48,80`
+- Settle windows: `0,10,20,30,45,60,90` seconds
+- Duration: `60` minutes
+- Seeds: `8` deterministic scenarios
+
+Custom sweep:
+
+```bash
+npm run simulate:pairing-pareto -- --players 16,20,24 --settleSeconds 10,20,30,45 --seedCount 20 --durationMinutes 60
+```
+
+Generated outputs:
+
+- `backend/test-output/pairing-pareto-*.html`: visual report with plots.
+- `backend/test-output/pairing-pareto-*.csv`: aggregate table for spreadsheets.
+- `backend/test-output/pairing-pareto-*.json`: full machine-readable report.
+
+The Pareto report does not choose a winner. It marks clearly problematic configurations:
+
+- Too few games: more than 15% below the best throughput for the same player count and algorithm.
+- Long waits: waits over 8 minutes, frequent waits over 5 minutes, or average wait at least 2.5 minutes.
+- Thin queue: average pool below the configured player-count threshold.
+
+Use the non-problematic Pareto points as the discussion set, then choose based on event policy: faster throughput vs fuller pairing choices.


### PR DESCRIPTION
## Summary

Replaces the legacy greedy Arena batch pairing path with weighted graph matching using Edmonds blossom matching over legal player-pair edges. Adds simulation tooling for graph-vs-greedy comparison and settle-window sweeps, makes the pairing settle window environment-configurable with a 30s default, and adds operator documentation for running OTB Arena tournaments.

## Changes

- `selectBatchPairings` now uses graph matching by default via `selectGraphBatchPairings`.
- Legal pair edges are filtered by `pairingScorer.evaluatePair`, then weighted by cost factors including pair score, head-to-head repeats, rank/rating/RD/berserk gaps, color stress, and wait time.
- Matching is solved per connected component using `edmonds-blossom-fixed` as maximum-cardinality maximum-weight matching over legal edges.
- `selectGreedyBatchPairings` remains exported for simulations and baseline comparisons.
- Added `PAIRING_SETTLE_MS` support through `pairingConfig.js`, `.env.example`, and `docker-compose.yml`.
- Raised the default settle window to `30_000ms`, while treating the initial tournament queue as already settled so round 1 is not delayed.
- Added realistic pairing comparison and Pareto sweep scripts under `backend/test-scripts/`.
- Added `docs/tournament-operations.md` and updated `README.md` with install, configuration, validation, simulation, and tournament-running instructions.

## Validation

- `cd backend && CORS_ORIGIN=http://localhost APP_MODE=test NODE_ENV=test npm test -- --runInBand`
- `cd backend && npm run simulate:pairing-comparison -- --players 20 --durationMinutes 60 --settleSeconds 30 --seed 20260519`
- `cd backend && npm run simulate:pairing-pareto`
